### PR TITLE
service-account-credentials: specify SA key file through SA_KEY_FILE env var

### DIFF
--- a/examples/service-account-credentials/main.py
+++ b/examples/service-account-credentials/main.py
@@ -26,8 +26,10 @@ def main():
         # specify YDB_DATABASE environment variable.
         database=os.getenv("YDB_DATABASE"),
         # construct the service account credentials instance
+        #   service account key should be in the local file,
+        #   and SA_KEY_FILE environment variable should point to it
         credentials=ydb.iam.ServiceAccountCredentials.from_file(
-            "~/.ydb/sa.json",
+            os.getenv("SA_KEY_FILE"),
         ),
     )
 


### PR DESCRIPTION
Minor change in the service-account-credentials to avoid using the fixed file name of the key file (which does not work on MacOS or Windows anyway).

I hereby agree to the terms of the CLA available at https://yandex.ru/legal/cla/?lang=ru