### PR TITLE
basic_example_v1: added how-to-run.txt

### DIFF
--- a/examples/basic_example_v1/README.md
+++ b/examples/basic_example_v1/README.md
@@ -2,9 +2,11 @@ Running this sample with the managed YDB instance in Yandex Cloud
 ---
 
 (0) Install the yc command line tool
+
 https://cloud.yandex.ru/docs/cli/operations/install-cli
 
 (1) Create the service account using the YC Web Console, and assign it the ydb.editor role.
+
 Alternatively use the following shell snippet:
 
 ```bash
@@ -20,6 +22,7 @@ yc resource-manager folder add-access-binding $YC_FOLDER --role ydb.editor --sub
 ```
 
 (2) Generate the service account key to be used for authentication.
+
 Note: unfortunately, right now YC Web Console does not offer a way to generate the SA key
 with its Web interface.
 
@@ -28,6 +31,7 @@ yc iam key create --service-account-name $SA_NAME --output $HOME/key-ydb-sa-0.js
 ```
 
 (3) Obtain the endpoint and database path from the Web Console.
+
 Alternatively, use the following command to grab the required data in the shell:
 
 ```bash

--- a/examples/basic_example_v1/README.md
+++ b/examples/basic_example_v1/README.md
@@ -1,5 +1,5 @@
 Running this sample with the managed YDB instance in Yandex Cloud
-*********************************************************************************
+---
 
 (0) Install the yc command line tool
 https://cloud.yandex.ru/docs/cli/operations/install-cli
@@ -7,6 +7,7 @@ https://cloud.yandex.ru/docs/cli/operations/install-cli
 (1) Create the service account using the YC Web Console, and assign it the ydb.editor role.
 Alternatively use the following shell snippet:
 
+```bash
 # Specify the Yandex Cloud folder and service account name
 export YC_FOLDER=mzinal
 export SA_NAME=ydb-sa-0
@@ -16,20 +17,28 @@ yc iam service-account create $SA_NAME
 export SA_ID=`yc iam service-account get --name $SA_NAME | sed -n 's/^id: \(.*\)$/\1/p'`
 # Assign the ydb.editor role for the specified YC folder to the service account just created
 yc resource-manager folder add-access-binding $YC_FOLDER --role ydb.editor --subject serviceAccount:$SA_ID 
+```
 
 (2) Generate the service account key to be used for authentication.
 Note: unfortunately, right now YC Web Console does not offer a way to generate the SA key
 with its Web interface.
 
+```bash
 yc iam key create --service-account-name $SA_NAME --output $HOME/key-ydb-sa-0.json
+```
 
 (3) Obtain the endpoint and database path from the Web Console.
-Alternatively, use the following command to grab it in the shell:
+Alternatively, use the following command to grab the required data in the shell:
 
-yc ydb db get --name ydb406
+```bash
+yc ydb db get --name ydb1
+```
+
+`ydb1` value in the command above is the logical name of the YDB managed database.
 
 (4) Run the sample:
 
+```bash
 # Set the path to the service account key file
 export YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS=$HOME/key-ydb-sa-0.json
 # Set the database path and its endpoint
@@ -37,3 +46,4 @@ export YDB_ENDPOINT=grpcs://ydb.serverless.yandexcloud.net:2135
 export YDB_DATABASE=/ru-central1/b1gfvslmokutuvt2g019/etnvbffeqegu1ub2rg2o
 # Run the script
 python3 __main__.py -e $YDB_ENDPOINT -d $YDB_DATABASE
+```

--- a/examples/basic_example_v1/README.md
+++ b/examples/basic_example_v1/README.md
@@ -1,11 +1,16 @@
 Running this sample with the managed YDB instance in Yandex Cloud
 ---
 
-(0) Install the yc command line tool
+(0) Install the required Python dependencies
+
+python3 -m pip install iso8601
+python3 -m pip install 'ydb[yc]'
+
+(1) Install the yc command line tool
 
 https://cloud.yandex.ru/docs/cli/operations/install-cli
 
-(1) Create the service account using the YC Web Console, and assign it the ydb.editor role.
+(2) Create the service account using the YC Web Console, and assign it the ydb.editor role.
 
 Alternatively use the following shell snippet:
 
@@ -21,7 +26,7 @@ export SA_ID=`yc iam service-account get --name $SA_NAME | sed -n 's/^id: \(.*\)
 yc resource-manager folder add-access-binding $YC_FOLDER --role ydb.editor --subject serviceAccount:$SA_ID 
 ```
 
-(2) Generate the service account key to be used for authentication.
+(3) Generate the service account key to be used for authentication.
 
 Note: unfortunately, right now YC Web Console does not offer a way to generate the SA key
 with its Web interface.
@@ -30,7 +35,7 @@ with its Web interface.
 yc iam key create --service-account-name $SA_NAME --output $HOME/key-ydb-sa-0.json
 ```
 
-(3) Obtain the endpoint and database path from the Web Console.
+(4) Obtain the endpoint and database path from the Web Console.
 
 Alternatively, use the following command to grab the required data in the shell:
 
@@ -40,7 +45,7 @@ yc ydb db get --name ydb1
 
 `ydb1` value in the command above is the logical name of the YDB managed database.
 
-(4) Run the sample:
+(5) Run the sample:
 
 ```bash
 # Set the path to the service account key file

--- a/examples/basic_example_v1/how-to-run.txt
+++ b/examples/basic_example_v1/how-to-run.txt
@@ -1,0 +1,39 @@
+Running this sample with the managed YDB instance in Yandex Cloud
+*********************************************************************************
+
+(0) Install the yc command line tool
+https://cloud.yandex.ru/docs/cli/operations/install-cli
+
+(1) Create the service account using the YC Web Console, and assign it the ydb.editor role.
+Alternatively use the following shell snippet:
+
+# Specify the Yandex Cloud folder and service account name
+export YC_FOLDER=mzinal
+export SA_NAME=ydb-sa-0
+# Create the service account
+yc iam service-account create $SA_NAME
+# Obtain the service account id
+export SA_ID=`yc iam service-account get --name $SA_NAME | sed -n 's/^id: \(.*\)$/\1/p'`
+# Assign the ydb.editor role for the specified YC folder to the service account just created
+yc resource-manager folder add-access-binding $YC_FOLDER --role ydb.editor --subject serviceAccount:$SA_ID 
+
+(2) Generate the service account key to be used for authentication.
+Note: unfortunately, right now YC Web Console does not offer a way to generate the SA key
+with its Web interface.
+
+yc iam key create --service-account-name $SA_NAME --output $HOME/key-ydb-sa-0.json
+
+(3) Obtain the endpoint and database path from the Web Console.
+Alternatively, use the following command to grab it in the shell:
+
+yc ydb db get --name ydb406
+
+(4) Run the sample:
+
+# Set the path to the service account key file
+export YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS=$HOME/key-ydb-sa-0.json
+# Set the database path and its endpoint
+export YDB_ENDPOINT=grpcs://ydb.serverless.yandexcloud.net:2135
+export YDB_DATABASE=/ru-central1/b1gfvslmokutuvt2g019/etnvbffeqegu1ub2rg2o
+# Run the script
+python3 __main__.py -e $YDB_ENDPOINT -d $YDB_DATABASE


### PR DESCRIPTION
Added the instruction to run the basic example using the managed YDB instance in the Yandex Cloud.
In practice this step confuses some users, so the instruction may allow them to get up and running.

I hereby agree to the terms of the CLA available at https://yandex.ru/legal/cla/?lang=ru