### PR TITLE
fix error message logging

### DIFF
--- a/ydb/aio/iam.py
+++ b/ydb/aio/iam.py
@@ -126,7 +126,8 @@ class MetadataUrlCredentials(AbstractExpiringTokenCredentials):
             ) as response:
                 if not response.ok:
                     self.logger.error(
-                        "Error while getting token from metadata: %s" % await response.text()
+                        "Error while getting token from metadata: %s"
+                        % await response.text()
                     )
                 response.raise_for_status()
                 return await response.json()

--- a/ydb/aio/iam.py
+++ b/ydb/aio/iam.py
@@ -126,7 +126,7 @@ class MetadataUrlCredentials(AbstractExpiringTokenCredentials):
             ) as response:
                 if not response.ok:
                     self.logger.error(
-                        "Error while getting token from metadata: %s" % response.text()
+                        "Error while getting token from metadata: %s" % await response.text()
                     )
                 response.raise_for_status()
                 return await response.json()


### PR DESCRIPTION
response.text() is async here, so without await we will get:

```
Error while getting token from metadata: <coroutine object ClientResponse.text at 0x7f6958452140>
```