### PR TITLE
add unknown item type to scheme ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Support `TYPE_UNSPECIFIED` item type to scheme ls
+
 ## 2.12.0 ##
 * Fixed error message while get token from metadata with asyncio iam
 * Add `SnapshotReadOnly` transaction mode support to `session.transaction`

--- a/ydb/scheme_test.py
+++ b/ydb/scheme_test.py
@@ -1,0 +1,30 @@
+from ydb.scheme import (
+    SchemeEntryType,
+    _wrap_scheme_entry,
+    _wrap_list_directory_response,
+)
+from ydb._apis import ydb_scheme
+
+
+def test_wrap_scheme_entry():
+    assert (
+        _wrap_scheme_entry(ydb_scheme.Entry(type=1)).type is SchemeEntryType.DIRECTORY
+    )
+    assert _wrap_scheme_entry(ydb_scheme.Entry(type=17)).type is SchemeEntryType.TOPIC
+
+    assert (
+        _wrap_scheme_entry(ydb_scheme.Entry()).type is SchemeEntryType.TYPE_UNSPECIFIED
+    )
+    assert (
+        _wrap_scheme_entry(ydb_scheme.Entry(type=10)).type
+        is SchemeEntryType.TYPE_UNSPECIFIED
+    )
+    assert (
+        _wrap_scheme_entry(ydb_scheme.Entry(type=1001)).type
+        is SchemeEntryType.TYPE_UNSPECIFIED
+    )
+
+
+def test_wrap_list_directory_response():
+    d = _wrap_list_directory_response(None, ydb_scheme.ListDirectoryResponse())
+    assert d.type is SchemeEntryType.TYPE_UNSPECIFIED


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfixsupport to scheme
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

[Issue Number: 74](https://github.com/ydb-platform/ydb-python-sdk/issues/74)

## What is the new behavior?

Support UNKNOWN item type for scheme listing.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
