### PR TITLE
ignore content_type from credentials provider

### DIFF
--- a/ydb/aio/iam.py
+++ b/ydb/aio/iam.py
@@ -130,7 +130,9 @@ class MetadataUrlCredentials(AbstractExpiringTokenCredentials):
                         % await response.text()
                     )
                 response.raise_for_status()
-                return await response.json()
+                # response from default metadata credentials provider
+                # contains text/plain content type.
+                return await response.json(content_type=None)
 
 
 class ServiceAccountCredentials(JWTIamCredentials):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Yes!

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Default metadata credentials provider in yandex cloud environment (http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token) returns access token in json format, but with **text/plain** content type.
This is wrong, but code from ```iam.auth.MetadataUrlCredentials._make_token_request()``` ignores content type and everything works fine in sync implementation.
On the other hand, its async alternative ```aio.iam.MetadataUrlCredentials._make_token_request()``` fails with wrong content type error.

Issue Number: N/A

## What is the new behavior?

Now we ignore content type from metadata credentials provider. This is also wrong, but acceptable, since sync implementation also do this.

## Other information

