### PR TITLE
fix passing set to execute params

### DIFF
--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -29,7 +29,7 @@ from uuid import uuid4
         ('{"foo":"bar"}', "JsonDocument"),
         (uuid4(), "Uuid"),
         ([1, 2, 3], "List<Int8>"),
-        # ({1, 2, 3}, "Set<Int8>"),  # FIXME: AttributeError: 'set' object has no attribute 'items'
+        ({1: None, 2: None, 3: None}, "Set<Int8>"),
         ([b"a", b"b", b"c"], "List<String>"),
         ({"a": 1001, "b": 1002}, "Dict<Utf8, Int32>"),
         (("a", 1001), "Tuple<Utf8, Int32>"),
@@ -47,7 +47,6 @@ async def test_types(driver, database, value, ydb_type):
     prepared = await session.prepare(
         f"DECLARE $param as {ydb_type}; SELECT $param as value"
     )
-
     result = await session.transaction().execute(
         prepared, {"$param": value}, commit_tx=True
     )

--- a/ydb/convert.py
+++ b/ydb/convert.py
@@ -214,9 +214,10 @@ def _dict_to_pb(type_pb, value):
     for key, payload in value.items():
         kv_pair = value_pb.pairs.add()
         kv_pair.key.MergeFrom(_from_native_value(type_pb.dict_type.key, key))
-        kv_pair.payload.MergeFrom(
-            _from_native_value(type_pb.dict_type.payload, payload)
-        )
+        if payload:
+            kv_pair.payload.MergeFrom(
+                _from_native_value(type_pb.dict_type.payload, payload)
+            )
     return value_pb
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ydb-platform/ydb-python-sdk/issues/104

## What is the new behavior?

Use Dict with None values to pass Set to ydb
