### PR TITLE
fix check retriable for idempotent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix error of check retriable error for idempotent operations (error exist since 2.12.1)
+
 ## 2.12.1 ##
 * Supported `TYPE_UNSPECIFIED` item type to scheme ls
 * Fixed error while request iam token with bad content type in metadata

--- a/ydb/_errors.py
+++ b/ydb/_errors.py
@@ -49,9 +49,10 @@ def check_retriable_error(err, retry_settings, attempt):
 
     if retry_settings.idempotent:
         for t in _errors_retriable_slow_backoff_idempotent_types:
-            return ErrorRetryInfo(
-                True, retry_settings.slow_backoff.calc_timeout(attempt)
-            )
+            if isinstance(err, t):
+                return ErrorRetryInfo(
+                    True, retry_settings.slow_backoff.calc_timeout(attempt)
+                )
 
     return ErrorRetryInfo(False, None)
 

--- a/ydb/table_test.py
+++ b/ydb/table_test.py
@@ -132,4 +132,9 @@ def test_retry_operation_impl(monkeypatch):
         check_retriable_error(issues.Unavailable, retry_once_settings.fast_backoff)
 
     check_unretriable_error(issues.Error, True)
+    with mock.patch.object(retry_once_settings, "idempotent", True):
+        check_unretriable_error(issues.Error, True)
+
     check_unretriable_error(TestException, False)
+    with mock.patch.object(retry_once_settings, "idempotent", True):
+        check_unretriable_error(TestException, False)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Always retry ydb errors for idempotent operations.

## What is the new behavior?
Check if error is retriable for idempotent
