### PR TITLE
can use datetime.date as param in execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed error while passing date parameter in execute
+
 ## 2.12.2 ##
 * Fix error of check retriable error for idempotent operations (error exist since 2.12.1)
 

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -62,9 +62,9 @@ test_dt_today = datetime.today()
 @pytest.mark.parametrize(
     "value,ydb_type,result_value",
     [
-        # FIXME: TypeError: 'datetime.date'/'datetime.datetime' object cannot be interpreted as an integer
-        # (test_today, 'Date', test_today),
+        # FIXME: TypeError: 'datetime.datetime' object cannot be interpreted as an integer
         # (test_dt_today, "Datetime", test_dt_today),
+        (test_today, "Date", test_today),
         (365, "Date", date(1971, 1, 1)),
         (3600 * 24 * 365, "Datetime", datetime(1971, 1, 1, 0, 0)),
         (test_td, "Interval", test_td),

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -12,6 +12,7 @@ from google.protobuf import struct_pb2
 
 _SECONDS_IN_DAY = 60 * 60 * 24
 _EPOCH = datetime(1970, 1, 1)
+
 if six.PY3:
     _from_bytes = None
 else:
@@ -20,13 +21,20 @@ else:
         return _utilities.from_bytes(x)
 
 
-def _from_date_number(x, table_client_settings):
+def _from_date(x, table_client_settings):
     if (
         table_client_settings is not None
         and table_client_settings._native_date_in_result_sets
     ):
-        return date.fromordinal(x + date(1970, 1, 1).toordinal())
-    return x
+        return _EPOCH.date() + timedelta(days=x.uint32_value)
+    return x.uint32_value
+
+
+def _to_date(pb, value):
+    if isinstance(value, date):
+        pb.uint32_value = (value - _EPOCH.date()).days
+    else:
+        pb.uint32_value = value
 
 
 def _from_datetime_number(x, table_client_settings):
@@ -122,8 +130,9 @@ class PrimitiveType(enum.Enum):
     UUID = (_apis.primitive_types.UUID, None, _to_uuid, _from_uuid)
     Date = (
         _apis.primitive_types.DATE,
-        "uint32_value",
-        _from_date_number,
+        None,
+        _from_date,
+        _to_date,
     )
     Datetime = (
         _apis.primitive_types.DATETIME,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Bugfix with passing datetime.date in params

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Issue Number: https://github.com/ydb-platform/ydb-python-sdk/issues/163