### PR TITLE
Fix flaky fail unit test from cause in integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
         pip install tox==4.2.6
 
     - name: Run unit tests
-      run: tox -e ${{ matrix.environment }} ydb
+      run: tox -e ${{ matrix.environment }} -- ydb
 
     - name: Run integration tests
-      run: tox -e ${{ matrix.environment }} tests
+      run: tox -e ${{ matrix.environment }} -- tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: unit-${{ github.ref }}-${{ matrix.environment }}-${{ matrix.python-version }}
+      group: unit-${{ github.ref }}-${{ matrix.environment }}-${{ matrix.python-version }}-${{ matrix.folder }}
       cancel-in-progress: true
 
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
+      fail-fast: false
       group: unit-${{ github.ref }}-${{ matrix.environment }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
@@ -26,9 +27,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Install tox
       run: |
         python -m pip install --upgrade pip
         pip install tox==4.2.6
-    - name: Test with tox
-      run: tox -e ${{ matrix.environment }}
+
+    - name: Run unit tests
+      run: tox -e ${{ matrix.environment }} ydb
+
+    - name: Run integration tests
+      run: tox -e ${{ matrix.environment }} tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,12 @@ jobs:
       matrix:
         python-version: [3.8]
         environment: [py, py-tls, py-proto3, py-tls-proto3]
+        folder: [ydb, tests]
+        exclude:
+          - environment: py-tls
+            folder: ydb
+          - environment: py-tls-proto3
+            folder: ydb
 
     steps:
     - uses: actions/checkout@v1
@@ -34,7 +40,4 @@ jobs:
         pip install tox==4.2.6
 
     - name: Run unit tests
-      run: tox -e ${{ matrix.environment }} -- ydb
-
-    - name: Run integration tests
-      run: tox -e ${{ matrix.environment }} -- tests
+      run: tox -e ${{ matrix.environment }} -- ${{ matrix.folder }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      fail-fast: false
       group: unit-${{ github.ref }}-${{ matrix.environment }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.8]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,8 +11,8 @@ docker==5.0.0
 docker-compose==1.29.2
 dockerpty==0.4.1
 docopt==0.6.2
-grpcio==1.42.0
-grpcio-tools==1.42.0
+grpcio==1.47.0
+grpcio-tools==1.47.0
 idna==3.2
 importlib-metadata==4.6.1
 iniconfig==1.1.1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Run integration and unit tests in one pytest process
It is bad because leaked process/coroutines from integration test (for example background re-connection after stop docker container) may use mocked object and  fail unit tests.

## New behaviour
Run integration and unit tests in different processes for prevent use mocks by real code
