### PR TITLE
close grpc streams when stream reader/writer closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Close grpc streams while closing readers/writers
 * Add control plane operations for topic api: create, drop
 
 ## 3.0.1b4 ##

--- a/tests/topics/test_topic_reader.py
+++ b/tests/topics/test_topic_reader.py
@@ -9,3 +9,4 @@ class TestTopicWriterAsyncIO:
         reader = driver.topic_client.topic_reader(topic_consumer, topic_path)
 
         assert await reader.receive_batch() is not None
+        await reader.close()

--- a/ydb/_topic_common/test_helpers.py
+++ b/ydb/_topic_common/test_helpers.py
@@ -8,19 +8,35 @@ from .._grpc.grpcwrapper.common_utils import IToProto, IGrpcWrapperAsyncIO
 class StreamMock(IGrpcWrapperAsyncIO):
     from_server: asyncio.Queue
     from_client: asyncio.Queue
+    _closed: bool
 
     def __init__(self):
         self.from_server = asyncio.Queue()
         self.from_client = asyncio.Queue()
+        self._closed = False
 
     async def receive(self) -> typing.Any:
+        if self._closed:
+            raise Exception("read from closed StreamMock")
+
         item = await self.from_server.get()
+        if item is None:
+            raise StopAsyncIteration()
         if isinstance(item, Exception):
             raise item
         return item
 
     def write(self, wrap_message: IToProto):
+        if self._closed:
+            raise Exception("write to closed StreamMock")
         self.from_client.put_nowait(wrap_message)
+
+    def close(self):
+        if self._closed:
+            return
+
+        self._closed = True
+        self.from_server.put_nowait(None)
 
 
 async def wait_condition(f: typing.Callable[[], bool], timeout=1):

--- a/ydb/_topic_reader/topic_reader_asyncio.py
+++ b/ydb/_topic_reader/topic_reader_asyncio.py
@@ -496,6 +496,7 @@ class ReaderStream:
         self._closed = True
         self._set_first_error(TopicReaderStreamClosedError())
         self._state_changed.set()
+        self._stream.close()
 
         for task in self._background_tasks:
             task.cancel()

--- a/ydb/_topic_writer/topic_writer_asyncio.py
+++ b/ydb/_topic_writer/topic_writer_asyncio.py
@@ -322,6 +322,7 @@ class WriterAsyncIOReconnector:
                 done, pending = await asyncio.wait(
                     [send_loop, receive_loop], return_when=asyncio.FIRST_COMPLETED
                 )
+                stream_writer.close()
                 done.pop().result()
             except issues.Error as err:
                 # todo log error
@@ -416,6 +417,9 @@ class WriterAsyncIOStream:
         token_getter: TokenGetterFuncType,
     ):
         self._token_getter = token_getter
+
+    def close(self):
+        self._stream.close()
 
     @staticmethod
     async def create(

--- a/ydb/_topic_writer/topic_writer_asyncio.py
+++ b/ydb/_topic_writer/topic_writer_asyncio.py
@@ -296,6 +296,7 @@ class WriterAsyncIOReconnector:
             pending = []
 
             # noinspection PyBroadException
+            stream_writer = None
             try:
                 stream_writer = await WriterAsyncIOStream.create(
                     self._driver, self._init_message, self._get_token
@@ -339,6 +340,8 @@ class WriterAsyncIOReconnector:
                 self._stop(err)
                 return
             finally:
+                if stream_writer:
+                    stream_writer.close()
                 if len(pending) > 0:
                     for task in pending:
                         task.cancel()

--- a/ydb/_topic_writer/topic_writer_asyncio_test.py
+++ b/ydb/_topic_writer/topic_writer_asyncio_test.py
@@ -158,19 +158,36 @@ class TestWriterAsyncIOReconnector:
         from_client: asyncio.Queue
         from_server: asyncio.Queue
 
+        _closed: bool
+
         def __init__(self):
             self.last_seqno = 0
             self.from_server = asyncio.Queue()
             self.from_client = asyncio.Queue()
+            self._closed = False
 
         def write(self, messages: typing.List[InternalMessage]):
+            if self._closed:
+                raise Exception("write to closed StreamWriterMock")
+
             self.from_client.put_nowait(messages)
 
         async def receive(self) -> StreamWriteMessage.WriteResponse:
+            if self._closed:
+                raise Exception("read from closed StreamWriterMock")
+
             item = await self.from_server.get()
             if isinstance(item, Exception):
                 raise item
             return item
+
+        def close(self):
+            if self._closed:
+                return
+
+            self.from_server.put_nowait(
+                Exception("waited message while StreamWriterMock closed")
+            )
 
     @pytest.fixture(autouse=True)
     async def stream_writer_double_queue(self, monkeypatch):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
grpc streams for topic reader/writer closing never.

## What is the new behavior?
Close grpc stream with stream reader/writer
