### PR TITLE
Fix six require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Add six package to requirements
 * Fixed error while passing date parameter in execute
 
 ## 2.12.2 ##

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-grpcio==1.39.0
+aiohttp==3.7.4
+enum-compat>=0.0.1
+grpcio>=1.5.0
 packaging
 protobuf>3.13.0,<5.0.0
 pytest==6.2.4
-aiohttp==3.7.4
 six<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ packaging
 protobuf>3.13.0,<5.0.0
 pytest==6.2.4
 aiohttp==3.7.4
+six<2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setuptools.setup(
         "protobuf>=3.13.0",
         "grpcio>=1.5.0",
         "enum-compat>=0.0.1",
-        "packaging"
+        "packaging",
+        "six<2",
     ),
     options={"bdist_wheel": {"universal": True}},
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,13 @@ import setuptools
 with open("README.md", "r") as r:
     long_description = r.read()
 
+with open("requirements.txt") as r:
+    requirements = []
+    for line in r.readlines():
+        line = line.strip()
+        if line != "":
+            requirements.append(line)
+
 setuptools.setup(
     name="ydb",
     version="2.12.2",  # AUTOVERSION
@@ -23,13 +30,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=(
-        "protobuf>=3.13.0",
-        "grpcio>=1.5.0",
-        "enum-compat>=0.0.1",
-        "packaging",
-        "six<2",
-    ),
+    install_requires=requirements,  # requirements.txt
     options={"bdist_wheel": {"universal": True}},
     extras_require={
         "yc": ["yandexcloud", ],


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
1. not required six package
2. manual list of packages synced between requirements.txt and requirements in setup.py

## What is the new behavior?
1. Add six to requirements
2. Auto read requirements.txt for setup.py
