### PR TITLE
Connect to YDB with credentials from env

### DIFF
--- a/examples/basic_example_v1/basic_example.py
+++ b/examples/basic_example_v1/basic_example.py
@@ -312,7 +312,7 @@ def ensure_path_exists(driver, database, path):
 
 
 def run(endpoint, database, path):
-    with ydb.Driver(endpoint=endpoint, database=database) as driver:
+    with ydb.Driver(endpoint=endpoint, database=database, credentials=ydb.credentials_from_env_variables()) as driver:
         driver.wait(timeout=5, fail_fast=True)
 
         with ydb.SessionPool(driver) as pool:


### PR DESCRIPTION
Without the parameter `credential=ydb.credentials_from_env_variables()`, anonymous access will be used, resulting in an error: "Authentication failed, access denied without user token" on run `python3 __main__.py -e $YDB_ENDPOINT -d $YDB_DATABASE`