### PR TITLE
Use metadata as default credentials in credentials_from_env_variables

### DIFF
--- a/ydb/driver.py
+++ b/ydb/driver.py
@@ -54,10 +54,12 @@ def credentials_from_env_variables(tracer=None):
             ctx.trace({"credentials.access_token": True})
             return credentials_impl.AuthTokenCredentials(access_token)
 
-        ctx.trace({
-            "credentials.env_default": True,
-            "credentials.metadata": True,
-        })
+        ctx.trace(
+            {
+                "credentials.env_default": True,
+                "credentials.metadata": True,
+            }
+        )
         return iam.MetadataUrlCredentials(tracer=tracer)
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Use anonymous cred if no env variables

## What is the new behavior?
Use metadata credentials
