### PR TITLE
fix keep_in_cache flag alg

### DIFF
--- a/ydb/_tx_ctx_impl.py
+++ b/ydb/_tx_ctx_impl.py
@@ -109,7 +109,7 @@ def _construct_tx_settings(tx_state):
 def execute_request_factory(session_state, tx_state, query, parameters, commit_tx, settings):
     data_query, query_id = session_state.lookup(query)
     parameters_types = {}
-    keep_in_cache = False
+
     if query_id is not None:
         query_pb = _apis.ydb_table.Query(id=query_id)
         parameters_types = data_query.parameters_types
@@ -119,20 +119,26 @@ def execute_request_factory(session_state, tx_state, query, parameters, commit_t
             yql_text = data_query.yql_text
             parameters_types = data_query.parameters_types
         elif isinstance(query, types.DataQuery):
-            if settings is not None and hasattr(settings, "keep_in_cache"):
-                keep_in_cache = settings.keep_in_cache
-            else:
-                # that is an instance of a data query and we don't know query id for id.
-                # so let's prepare it to keep in cache
-                keep_in_cache = True
             yql_text = query.yql_text
             parameters_types = query.parameters_types
         else:
             yql_text = query
         query_pb = _apis.ydb_table.Query(yql_text=yql_text)
     request = _apis.ydb_table.ExecuteDataQueryRequest(parameters=convert.parameters_to_pb(parameters_types, parameters))
+
+    if query_id is not None:
+        # SDK not send query text and nothing save to cache
+        keep_in_cache = False
+    elif settings is not None and hasattr(settings, "keep_in_cache"):
+        keep_in_cache = settings.keep_in_cache
+    elif parameters:
+        keep_in_cache = True
+    else:
+        keep_in_cache = False
+
     if keep_in_cache:
         request.query_cache_policy.keep_in_cache = True
+
     request.query.MergeFrom(query_pb)
     tx_control = _apis.ydb_table.TransactionControl()
     tx_control.commit_tx = commit_tx


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
not set keep_in_cache flag if query exist in local cache

## What is the new behavior?
set keep_in_cache flag independent of cache. Now it depends from settings and params. By default: True if query has params and False if query has not params.
