### PR TITLE
Fixed set keep_in_cache algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed set keep_in_cache algorithm
+
 ## 2.13.4 ##
 * fixed sqlalchemy get_columns method with not null columns
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
not set keep_in_cache flag if query exist in local cache

## What is the new behavior?
set keep_in_cache flag independent of cache. Now it depends from settings and params. By default: True if query has params and False if query has not params.
