### PR TITLE
raise exception if aquire session from stopped pool

### DIFF
--- a/tests/aio/test_session_pool.py
+++ b/tests/aio/test_session_pool.py
@@ -62,14 +62,14 @@ async def test_close_basic_logic_case_1(driver):
     waiter = asyncio.ensure_future(pool.acquire())
 
     await pool.stop()
-    waiter_sess = waiter.result()
-    assert not waiter_sess.initialized()
-    after_stop = await pool.acquire()
-    assert not after_stop.initialized()
+
+    with pytest.raises(ValueError):
+        waiter.result()
+
+    with pytest.raises(ValueError):
+        await pool.acquire()
 
     await pool.release(s)
-    await pool.release(after_stop)
-    await pool.release(waiter_sess)
     assert pool._active_count == 0
 
 
@@ -106,9 +106,9 @@ async def test_close_basic_logic_case_2(driver):
 
     assert pool._active_count == 0
 
-    sess = await pool.acquire()
+    with pytest.raises(ValueError):
+        await pool.acquire()
 
-    assert not sess.initialized()
     await pool.stop()
 
 

--- a/tests/aio/test_table.py
+++ b/tests/aio/test_table.py
@@ -1,0 +1,12 @@
+import pytest
+import ydb.aio
+
+
+@pytest.mark.asyncio
+class TestSessionPool:
+    async def test_checkout_from_stopped_pool(self, driver):
+        pool = ydb.aio.SessionPool(driver, 1)
+        await pool.stop()
+
+        with pytest.raises(ValueError):
+            await pool.acquire()

--- a/tests/session_pool.py
+++ b/tests/session_pool.py
@@ -1,0 +1,40 @@
+import pytest
+
+import ydb
+
+
+def test_close_basic_logic_case_1(driver_sync):
+    pool = ydb.SessionPool(driver_sync, 1)
+    s = pool.acquire()
+
+    pool.stop()
+
+    with pytest.raises(ValueError):
+        pool.acquire()
+
+    pool.release(s)
+    assert pool._pool_impl._active_count == 0
+
+
+def test_close_basic_logic_case_2(driver_sync):
+    pool = ydb.SessionPool(driver_sync, 10)
+    acquired = []
+
+    for _ in range(10):
+        acquired.append(pool.acquire())
+
+    for _ in range(3):
+        pool.release(acquired.pop(-1))
+
+    pool.stop()
+    assert pool._pool_impl._active_count == 7
+
+    while acquired:
+        pool.release(acquired.pop(-1))
+
+    assert pool._pool_impl._active_count == 0
+
+    with pytest.raises(ValueError):
+        pool.acquire()
+
+    pool.stop()

--- a/tests/table/table_test.py
+++ b/tests/table/table_test.py
@@ -1,4 +1,14 @@
+import pytest
 import ydb
+
+
+class TestSessionPool:
+    def test_checkout_from_stopped_pool(self, driver_sync):
+        pool = ydb.SessionPool(driver_sync, 1)
+        pool.stop()
+
+        with pytest.raises(ValueError):
+            pool.acquire()
 
 
 class TestTable:

--- a/ydb/_sp_impl.py
+++ b/ydb/_sp_impl.py
@@ -335,6 +335,10 @@ class SessionPoolImpl(object):
             self._destroy(session, "keep-alive-error")
 
     def acquire(self, blocking=True, timeout=None):
+        if self._should_stop.is_set():
+            self._logger.debug("Acquired not inited session")
+            raise ValueError("Take session from closed session pool.")
+
         waiter = self.subscribe()
         has_result = False
         if blocking:

--- a/ydb/_sp_impl.py
+++ b/ydb/_sp_impl.py
@@ -336,7 +336,7 @@ class SessionPoolImpl(object):
 
     def acquire(self, blocking=True, timeout=None):
         if self._should_stop.is_set():
-            self._logger.debug("Acquired not inited session")
+            self._logger.error("Take session from closed session pool")
             raise ValueError("Take session from closed session pool.")
 
         waiter = self.subscribe()

--- a/ydb/aio/table.py
+++ b/ydb/aio/table.py
@@ -342,7 +342,7 @@ class SessionPool:
 
         if self._should_stop.is_set():
             self._logger.debug("Acquired not inited session")
-            return self._create()
+            raise ValueError("Take session from closed session pool.")
 
         if retry_timeout is None:
             retry_timeout = timeout

--- a/ydb/aio/table.py
+++ b/ydb/aio/table.py
@@ -341,7 +341,7 @@ class SessionPool:
     async def acquire(self, timeout: float = None, retry_timeout: float = None, retry_num: int = None) -> ydb.ISession:
 
         if self._should_stop.is_set():
-            self._logger.debug("Acquired not inited session")
+            self._logger.error("Take session from closed session pool")
             raise ValueError("Take session from closed session pool.")
 
         if retry_timeout is None:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
return uninitialized session when acquire session from stopped pool

## Now
raise exception

Close #260