### PR TITLE
wait top stop background tasks before stop writer stream

### DIFF
--- a/ydb/_topic_writer/topic_writer_asyncio.py
+++ b/ydb/_topic_writer/topic_writer_asyncio.py
@@ -366,8 +366,7 @@ class WriterAsyncIOReconnector:
 
                 tasks = [send_loop, receive_loop]
                 done, _ = await asyncio.wait([send_loop, receive_loop], return_when=asyncio.FIRST_COMPLETED)
-                await stream_writer.close()
-                done.pop().result()
+                done.pop().result()  # need for raise exception - reason of stop task
             except issues.Error as err:
                 err_info = check_retriable_error(err, retry_settings, attempt)
                 if not err_info.is_retriable:
@@ -380,12 +379,12 @@ class WriterAsyncIOReconnector:
                 self._stop(err)
                 return
             finally:
-                if stream_writer:
-                    await stream_writer.close()
                 for task in tasks:
                     task.cancel()
                 if tasks:
                     await asyncio.wait(tasks)
+                if stream_writer:
+                    await stream_writer.close()
 
     async def _encode_loop(self):
         try:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

stop writer, then wait to stop background tasks

## What is the new behavior?

wait to stop all background tasks, then close writer