### PR TITLE
getting index type

### DIFF
--- a/ydb/table.py
+++ b/ydb/table.py
@@ -286,6 +286,7 @@ class TableIndex(object):
         self.index_columns = []
         # output only.
         self.status = None
+        self.type = None
 
     def with_global_index(self):
         self._pb.global_index.SetInParent()
@@ -300,6 +301,12 @@ class TableIndex(object):
     def to_pb(self):
         return self._pb
 
+
+@enum.unique
+class IndexType(enum.IntEnum):
+    SYNCHRONOUS = 0
+    ASYNCHRONOUS = 1
+    
 
 class ReplicationPolicy(object):
     def __init__(self):
@@ -1337,6 +1344,10 @@ class TableClient(BaseTableClient):
 def _make_index_description(index):
     result = TableIndex(index.name).with_index_columns(*tuple(col for col in index.index_columns))
     result.status = IndexStatus(index.status)
+    if index.HasField("global_async_index"):
+        result.type = IndexType(IndexType.ASYNCHRONOUS)
+    else:
+        result.type = IndexType(IndexType.SYNCHRONOUS)
     return result
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Метод session.describe_table возвращает в том числе объекты, описывающие индексы таблицы - TableIndex. Этот объект не содержит информации о типе индекса (синхронный или асинхронный), хотя эта информация есть в protobuf сообщении, на основе которого формируется объект.

Issue Number: #351

## What is the new behavior?

TableIndex содержать поле type -  enum, описывающий тип индекса.