### PR TITLE
set default one thread for encode/decode messages

### DIFF
--- a/ydb/topic.py
+++ b/ydb/topic.py
@@ -387,7 +387,11 @@ class TopicClient:
 
 @dataclass
 class TopicClientSettings:
-    encode_decode_threads_count: int = 4
+    # ATTENTION
+    # When set the encode_decode_threads_count - all custom encoders/decoders for topic reader/writer
+    # MUST be thread-safe
+    # because they will be called from parallel threads
+    encode_decode_threads_count: int = 1
 
 
 class TopicError(issues.Error):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

Was 4 threads for encode/decode messages
When use more then one thread for encode/decode messages it has difficult to detect races in encoders/decoders.

## What is the new behavior?
By default only one thread used for encode/decode messages
