### PR TITLE
fixed python2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed python2 compatibility 
+
 ## 2.15.0 ##
 * Fixed python2 compatibility
 

--- a/ydb/_errors.py
+++ b/ydb/_errors.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from . import issues
 
 _errors_retriable_fast_backoff_types = [
@@ -56,7 +54,6 @@ def check_retriable_error(err, retry_settings, attempt):
     return ErrorRetryInfo(False, None)
 
 
-@dataclass
 class ErrorRetryInfo:
     def __init__(self, is_retriable, sleep_timeout_seconds=None):
         self.is_retriable = is_retriable

--- a/ydb/scheme.py
+++ b/ydb/scheme.py
@@ -25,10 +25,6 @@ class SchemeEntryType(enum.IntEnum):
     REPLICATION = 16
     TOPIC = 17
 
-    @classmethod
-    def _missing_(cls, value):
-        return cls.TYPE_UNSPECIFIED
-
     @staticmethod
     def is_table(entry):
         """

--- a/ydb/scheme_test.py
+++ b/ydb/scheme_test.py
@@ -15,14 +15,6 @@ def test_wrap_scheme_entry():
     assert (
         _wrap_scheme_entry(ydb_scheme.Entry()).type is SchemeEntryType.TYPE_UNSPECIFIED
     )
-    assert (
-        _wrap_scheme_entry(ydb_scheme.Entry(type=10)).type
-        is SchemeEntryType.TYPE_UNSPECIFIED
-    )
-    assert (
-        _wrap_scheme_entry(ydb_scheme.Entry(type=1001)).type
-        is SchemeEntryType.TYPE_UNSPECIFIED
-    )
 
 
 def test_wrap_list_directory_response():


### PR DESCRIPTION
removed func _missing_ for SchemeEntryType

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

The library used functional, unavailable for python2: dataclasses and def _missing_ function for enum.
The pr remove the usages.
