### PR TITLE
Fix datetime timezoine aware usage

### DIFF
--- a/ydb/types.py
+++ b/ydb/types.py
@@ -5,7 +5,7 @@ import abc
 import enum
 import json
 from . import _utilities, _apis
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import typing
 import uuid
 import struct
@@ -90,7 +90,11 @@ def _from_timestamp(
 
 def _to_timestamp(pb: ydb_value_pb2.Value, value: typing.Union[datetime, int]):
     if isinstance(value, datetime):
-        pb.uint64_value = _timedelta_to_microseconds(value - _EPOCH)
+        if value.tzinfo:
+            epoch = _EPOCH.replace(tzinfo=timezone.utc)
+        else:
+            epoch = _EPOCH
+        pb.uint64_value = _timedelta_to_microseconds(value - epoch)
     else:
         pb.uint64_value = value
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fix bug with timezone aware datetime

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Now this code fails:
```python
text_query = "DECLARE $v AS Timestamp; SELECT $v"
    session.prepare(text_query)
    with session.transaction() as tx:
        return tx.execute(text_query, {"$v": datetime.now(timezone.utc)})
```
with error:
```
File "/Users/tretiak-rd/projects/ydb-python-sdk/ydb/types.py", line 97, in _to_timestamp
    pb.uint64_value = _timedelta_to_microseconds(value - _EPOCH)
TypeError: can't subtract offset-naive and offset-aware datetimes
```

It happens because _EPOCH is timezone naive datetime object:
```
_EPOCH = datetime(1970, 1, 1)
```

Issue Number: N/A

## What is the new behavior?
Code works well and returns datetime naive object, because the Timestamp type doesn't support timezone.
```python
text_query = "DECLARE $v AS Timestamp; SELECT $v"
    session.prepare(text_query)
    with session.transaction() as tx:
        return tx.execute(text_query, {"$v": datetime.now(timezone.utc)})
```
