### PR TITLE
Support max_{messages,bytes} parameters, when reading a batch through…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.11.5 ##
+* Added support for max_messages and max_bytes parameters, when reading a batch through a sync topic reader
+
 ## 3.11.4 ##
 * Added missing returns to time converters for topic options
 


### PR DESCRIPTION
Allow a client to control the amount of data it receives, when reading a batch through `TopicReaderSync`.

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`TopicReaderSync.receive_batch` ignores `max_messages` and `max_bytes` parameters, which means a client has no control over the amount of received data.

Issue Number: 365

## What is the new behavior?

`TopicReaderSync.receive_batch` now takes `max_messages` and `max_bytes` into account.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
