### PR TITLE
Fix: convert gRPC stream termination to YDB errors in async query client (issue #696)

### DIFF
--- a/tests/aio/query/conftest.py
+++ b/tests/aio/query/conftest.py
@@ -1,4 +1,9 @@
+from unittest import mock
+
+import grpc
 import pytest
+from grpc._cython import cygrpc
+
 from ydb.aio.query.session import QuerySession
 from ydb.aio.query.pool import QuerySessionPool
 
@@ -32,3 +37,22 @@ async def tx(session):
 async def pool(driver):
     async with QuerySessionPool(driver) as pool:
         yield pool
+
+
+@pytest.fixture
+async def ydb_terminates_streams_with_unavailable():
+    async def _patch(self):
+        message = await self._read()  # Read the first message
+        while message is not cygrpc.EOF:  # While the message is not empty, continue reading the stream
+            yield message
+            message = await self._read()
+
+        # Emulate stream termination
+        raise grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=await self.initial_metadata(),
+            trailing_metadata=await self.trailing_metadata(),
+        )
+
+    with mock.patch.object(grpc.aio._call._StreamResponseMixin, "_fetch_stream_responses", _patch):
+        yield

--- a/tests/aio/query/test_query_session.py
+++ b/tests/aio/query/test_query_session.py
@@ -1,4 +1,6 @@
 import pytest
+
+import ydb
 from ydb.aio.query.session import QuerySession
 
 
@@ -113,3 +115,13 @@ class TestAsyncQuerySession:
 
         assert res == [[1], [2]]
         assert counter == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("ydb_terminates_streams_with_unavailable")
+    async def test_terminated_stream_raises_ydb_error(self, session: QuerySession):
+        await session.create()
+
+        with pytest.raises(ydb.Unavailable):
+            async with await session.execute("select 1") as results:
+                async for _ in results:
+                    pass

--- a/tests/aio/query/test_query_transaction.py
+++ b/tests/aio/query/test_query_transaction.py
@@ -1,5 +1,6 @@
 import pytest
 
+import ydb
 from ydb.aio.query.transaction import QueryTxContext
 from ydb.query.transaction import QueryTxStateEnum
 
@@ -107,3 +108,13 @@ class TestAsyncQueryTransaction:
 
         assert res == [[1], [2]]
         assert counter == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("ydb_terminates_streams_with_unavailable")
+    async def test_terminated_stream_raises_ydb_error(self, tx: QueryTxContext):
+        await tx.begin()
+
+        with pytest.raises(ydb.Unavailable):
+            async with await tx.execute("select 1") as results:
+                async for _ in results:
+                    pass

--- a/ydb/aio/query/session.py
+++ b/ydb/aio/query/session.py
@@ -19,6 +19,7 @@ from ...query.session import (
 )
 
 from ..._constants import DEFAULT_INITIAL_RESPONSE_TIMEOUT
+from ..._errors import stream_error_converter
 
 
 class QuerySession(BaseQuerySession):
@@ -151,12 +152,13 @@ class QuerySession(BaseQuerySession):
         )
 
         return AsyncResponseContextIterator(
-            stream_it,
-            lambda resp: base.wrap_execute_query_response(
+            it=stream_it,
+            wrapper=lambda resp: base.wrap_execute_query_response(
                 rpc_state=None,
                 response_pb=resp,
                 session_state=self._state,
                 session=self,
                 settings=self._settings,
             ),
+            error_converter=stream_error_converter,
         )

--- a/ydb/aio/query/transaction.py
+++ b/ydb/aio/query/transaction.py
@@ -11,6 +11,7 @@ from ...query.transaction import (
     BaseQueryTxContext,
     QueryTxStateEnum,
 )
+from ..._errors import stream_error_converter
 
 logger = logging.getLogger(__name__)
 
@@ -181,8 +182,8 @@ class QueryTxContext(BaseQueryTxContext):
         )
 
         self._prev_stream = AsyncResponseContextIterator(
-            stream_it,
-            lambda resp: base.wrap_execute_query_response(
+            it=stream_it,
+            wrapper=lambda resp: base.wrap_execute_query_response(
                 rpc_state=None,
                 response_pb=resp,
                 session_state=self._session_state,
@@ -190,5 +191,6 @@ class QueryTxContext(BaseQueryTxContext):
                 commit_tx=commit_tx,
                 settings=self.session._settings,
             ),
+            error_converter=stream_error_converter,
         )
         return self._prev_stream


### PR DESCRIPTION
Fix: convert gRPC stream termination to YDB errors in async query client (issue #696)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When a server terminates an async result stream, the client surfaces raw grpc.aio exceptions (e.g., AioRpcError with StatusCode.UNAVAILABLE) from the iterator. This leaks gRPC types to callers and prevents consistent handling/retry based on YDB error classes.

Issue Number: #696

## What is the new behavior?

* Introduce `stream_error_converter` (`ydb/_errors.py`) that maps gRPC stream errors to YDB exceptions:

  * `UNAVAILABLE` → `ydb.issues.Unavailable`
  * `DEADLINE_EXCEEDED` → `ydb.issues.DeadlineExceed`
  * All other gRPC stream errors → wrapped in `ydb.issues.Error` with context.
* Extend `AsyncResponseIterator` (`ydb/aio/_utilities.py`) to accept an optional `error_converter` and apply it when `__anext__()` raises.
* Wire the converter into query streaming:

  * `ydb/aio/query/session.py` and `ydb/aio/query/transaction.py` pass `error_converter=stream_error_converter` to `AsyncResponseContextIterator`.
* Add tests to validate behavior:

  * New pytest fixture `ydb_terminates_streams_with_unavailable` that emulates server-side stream termination with `StatusCode.UNAVAILABLE`.
  * New tests ensure iteration over results raises `ydb.Unavailable` for both `QuerySession.execute` and `QueryTxContext.execute`.

**Result:** Callers now consistently receive YDB exceptions from async stream iterations, enabling uniform retry/error handling.

## Other information

* Tests added:

  * `tests/aio/query/test_query_session.py::test_terminated_stream_raises_ydb_error`
  * `tests/aio/query/test_query_transaction.py::test_terminated_stream_raises_ydb_error`
  * Supporting fixture in `tests/aio/query/conftest.py`.
* No public API changes intended, but **behavioral note**: code that previously caught raw `grpc.aio.AioRpcError` during iteration should now catch the corresponding YDB exception (`ydb.Unavailable`, etc.). This aligns with expected library semantics.