### PR TITLE
Fix invalid read_from usage

### DIFF
--- a/ydb/_grpc/grpcwrapper/ydb_topic.py
+++ b/ydb/_grpc/grpcwrapper/ydb_topic.py
@@ -483,7 +483,7 @@ class StreamReadMessage:
                     path=self.path,
                     partition_ids=self.partition_ids,
                     max_lag=proto_duration_from_timedelta(self.max_lag),
-                    read_from=proto_timestamp_from_datetime(self.read_from)
+                    read_from=proto_timestamp_from_datetime(self.read_from),
                 )
 
     @dataclass


### PR DESCRIPTION
Fix of invalid usage for `read_from` and `max_lag` fields inside TopicReadSettings. 

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently python throws error like this:

```bash
File "...../ydb/_grpc/grpcwrapper/ydb_topic.py", line 490, in to_proto
    res.read_from = read_from
    ^^^^^^^^^^^^^
AttributeError: Assignment not allowed to field "read_from" in protocol message object.
```

in case of trying to set `read_from` field for `TopicReaderSelector`. Foe example:
```python
driver.topic_client.reader(
    topic=ydb.TopicReaderSelector(
        path=self.config.responses_mode.topic_name,
        partitions=[v.partition_id for v in topic_info.partitions],
        read_from=datetime.datetime.now(datetime.timezone.utc),  # <<<<<<<<
    ),
    consumer=None,
    event_handler=YdbTopicDataClient._CustomEventHandler(),
)
```

due to assigning value to member variable

Issue Number: N/A

## What is the new behavior?

Construct whole object as is instead of setting each member separately. Alternative fix is to use `res.read_from.CopyFrom(read_from)` if preferred

## Other information

Most probably same issue happens for `max_lag` member but didn't tested


Context: https://protobuf.dev/reference/python/python-generated/#embedded_message


> You cannot do the following:
```
foo = Foo()
foo.bar = Bar()  # WRONG!
```
