### PR TITLE
QuerySessionPool: Cancel `queue.get` in case of cancel of parent coroutine.

### DIFF
--- a/ydb/aio/query/pool.py
+++ b/ydb/aio/query/pool.py
@@ -76,7 +76,14 @@ class QuerySessionPool:
         if session is None and self._current_size == self._size:
             queue_get = asyncio.ensure_future(self._queue.get())
             task_stop = asyncio.ensure_future(asyncio.ensure_future(self._should_stop.wait()))
-            done, _ = await asyncio.wait((queue_get, task_stop), return_when=asyncio.FIRST_COMPLETED)
+            try:
+                done, _ = await asyncio.wait((queue_get, task_stop), return_when=asyncio.FIRST_COMPLETED)
+            except asyncio.CancelledError:
+                task_stop.cancel()
+                cancelled = queue_get.cancel()
+                if not cancelled and not queue_get.exception():
+                    await self.release(queue_get.result())
+                raise
             if task_stop in done:
                 queue_get.cancel()
                 raise RuntimeError("An attempt to take session from closed session pool.")

--- a/ydb/aio/table.py
+++ b/ydb/aio/table.py
@@ -571,8 +571,9 @@ class SessionPool:
         try:
             done, _ = await asyncio.wait((task_wait, task_should_stop), return_when=asyncio.FIRST_COMPLETED)
         except asyncio.CancelledError:
+            task_should_stop.cancel()
             cancelled = task_wait.cancel()
-            if not cancelled:
+            if not cancelled and not task_wait.exception():
                 priority, session = task_wait.result()
                 self._active_queue.put_nowait((priority, session))
             raise


### PR DESCRIPTION
QuerySessionPool: Cancel `queue.get` in case of cancel of parent coroutine.

Issue is the same as the previous one in the Table API SessionPool: https://github.com/ydb-platform/ydb-python-sdk/pull/537

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In case of a cancel while `QuerySessionPool.acquire()` is waiting for a free session, a sub-task is not canceled. When there's a free session, it's acquired by this sub-task and lost.

Issue Number: N/A

## What is the new behavior?

Try to cancel sub-task `self._queue.get()` manually in case of `asyncio.CancelledError` error during execution of `ydb.aio.query.pool.QuerySessionPool.acquire`.
If it can't be cancelled, its result (acquired session) is released.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Script to reproduce

You need to have a running YDB at `localhost:2135`.
Script will never stop because of the bug, so you need to stop it manually (e.g. hit `ctrl+C`).

<details>

```python
import asyncio

import ydb


async def main():
    async with ydb.aio.Driver(endpoint="localhost:2135", database="/local") as driver:
        await driver.wait()
        pool = ydb.aio.query.QuerySessionPool(driver, size=1)
        asyncio.create_task(log(pool))
        await asyncio.gather(first_connection(pool), second_connection(pool), third_connection(pool))
        print("End of execution")
        await asyncio.sleep(2)


async def first_connection(pool: ydb.aio.SessionPool):
    print("First session acquiring")
    session = await pool.acquire()
    print("First session acquired")
    await asyncio.sleep(5)
    print("First session releasing")
    await pool.release(session)
    print("First session released")


async def second_connection(pool: ydb.aio.SessionPool):
    await asyncio.sleep(1)
    print("Second session acquiring")
    try:
        session = await asyncio.wait_for(pool.acquire(), timeout=1)
        # will not be called because of TimeoutError
        print("Second session acquired")
        print("Second session releasing")
        await pool.release(session)
        print("Second session released")
    except asyncio.exceptions.TimeoutError:
        print("Second session acquiring aborted")
    finally:
        print("Second function closed")


async def third_connection(pool: ydb.aio.SessionPool):
    await asyncio.sleep(2)
    print("Third session acquiring")
    session = await pool.acquire()
    print("Third session acquired")
    print("Third session releasing")
    await pool.release(session)
    print("Third session released")


async def log(pool):
    while True:
        print(
            f"Pool queue stats:\nPool.size: {pool._size}\nPool._current_size: {pool._current_size}\nQueue.size: {pool._queue.qsize()}"
        )
        await asyncio.sleep(0.5)


asyncio.run(main())
```

</details>

### Output before the changes

<details>

```
Pool queue stats:
Pool.size: 1
Pool._current_size: 0
Queue.size: 0
First session acquiring
First session acquired
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Second session acquiring
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Third session acquiring
Second session acquiring aborted
Second function closed
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
First session releasing
First session released
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Traceback (most recent call last):
  File "/Users/ya-bogdan/Library/Application Support/JetBrains/PyCharm2024.3/scratches/BILLDEV-5971_three_requests_pool.py", line 60, in <module>
    asyncio.run(main())
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1854, in _run_once
    event_list = self._selector.select(timeout)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/selectors.py", line 562, in select
    kev_list = self._selector.control(None, max_ev, timeout)
KeyboardInterrupt

Process finished with exit code 130 (interrupted by signal 2:SIGINT)
```

</details>

### Output after the changes

<details>

```
Pool queue stats:
Pool.size: 1
Pool._current_size: 0
Queue.size: 0
First session acquiring
First session acquired
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Second session acquiring
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Third session acquiring
Second session acquiring aborted
Second function closed
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 0
First session releasing
First session released
Third session acquired
Third session releasing
Third session released
End of execution
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 1
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 1
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 1
Pool queue stats:
Pool.size: 1
Pool._current_size: 1
Queue.size: 1

Process finished with exit code 0
```

</details>
