### PR TITLE
Add DescribeConsumer support in Topic SDK

### DIFF
--- a/ydb/_apis.py
+++ b/ydb/_apis.py
@@ -117,6 +117,7 @@ class TopicService(object):
 
     CreateTopic = "CreateTopic"
     DescribeTopic = "DescribeTopic"
+    DescribeConsumer = "DescribeConsumer"
     AlterTopic = "AlterTopic"
     DropTopic = "DropTopic"
     StreamRead = "StreamRead"

--- a/ydb/topic.py
+++ b/ydb/topic.py
@@ -6,6 +6,7 @@ __all__ = [
     "TopicClientSettings",
     "TopicCodec",
     "TopicConsumer",
+    "TopicConsumerDescription",
     "TopicAlterConsumer",
     "TopicAlterAutoPartitioningSettings",
     "TopicAutoPartitioningSettings",
@@ -87,6 +88,7 @@ from ._grpc.grpcwrapper import ydb_topic as _ydb_topic
 from ._grpc.grpcwrapper import ydb_topic_public_types as _ydb_topic_public_types
 from ._grpc.grpcwrapper.ydb_topic_public_types import (  # noqa: F401
     PublicDescribeTopicResult as TopicDescription,
+    PublicDescribeConsumerResult as TopicConsumerDescription,
     PublicMultipleWindowsStat as TopicStatWindow,
     PublicPartitionStats as TopicPartitionStats,
     PublicCodec as TopicCodec,
@@ -236,6 +238,35 @@ class TopicClientAsyncIO:
             _apis.TopicService.DescribeTopic,
             _create_result_wrapper(_ydb_topic.DescribeTopicResult),
         )  # type: _ydb_topic.DescribeTopicResult
+        return res.to_public()
+
+    async def describe_consumer(
+        self,
+        path: str,
+        consumer: str,
+        *,
+        include_stats: bool = False,
+        include_location: bool = False,
+    ) -> TopicConsumerDescription:
+        """
+        Describe topic's consumer.
+
+        :param path: full path to topic
+        :param consumer: consumer name
+        :param include_stats: include consumer statistics
+        :param include_location: include partition location
+        :return: consumer description
+        """
+        logger.debug("Describe consumer request: path=%s consumer=%s", path, consumer)
+        args = locals().copy()
+        del args["self"]
+        req = _ydb_topic_public_types.DescribeConsumerRequestParams(**args)
+        res = await self._driver(
+            req.to_proto(),
+            _apis.TopicService.Stub,
+            _apis.TopicService.DescribeConsumer,
+            _create_result_wrapper(_ydb_topic.DescribeConsumerResult),
+        )  # type: _ydb_topic.DescribeConsumerResult
         return res.to_public()
 
     async def drop_topic(self, path: str):
@@ -531,6 +562,37 @@ class TopicClient:
             _apis.TopicService.DescribeTopic,
             _create_result_wrapper(_ydb_topic.DescribeTopicResult),
         )  # type: _ydb_topic.DescribeTopicResult
+        return res.to_public()
+
+    def describe_consumer(
+        self,
+        path: str,
+        consumer: str,
+        *,
+        include_stats: bool = False,
+        include_location: bool = False,
+    ) -> TopicConsumerDescription:
+        """
+        Describe topic's consumer.
+
+        :param path: full path to topic
+        :param consumer: consumer name
+        :param include_stats: include consumer statistics
+        :param include_location: include partition location
+        :return: consumer description
+        """
+        logger.debug("Describe consumer request: path=%s consumer=%s", path, consumer)
+        args = locals().copy()
+        del args["self"]
+        self._check_closed()
+
+        req = _ydb_topic_public_types.DescribeConsumerRequestParams(**args)
+        res = self._driver(
+            req.to_proto(),
+            _apis.TopicService.Stub,
+            _apis.TopicService.DescribeConsumer,
+            _create_result_wrapper(_ydb_topic.DescribeConsumerResult),
+        )  # type: _ydb_topic.DescribeConsumerResult
         return res.to_public()
 
     def drop_topic(self, path: str):


### PR DESCRIPTION
Implements DescribeConsumer API call for Topic SDK, allowing users to get detailed information about a topic's consumer including partition stats and consumer offsets.

Closes #713
Closes #683 

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
