### PR TITLE
fix: handle asyncio.CancelledError as retriable in topic writer and reader

### DIFF
--- a/ydb/_grpc/grpcwrapper/common_utils.py
+++ b/ydb/_grpc/grpcwrapper/common_utils.py
@@ -234,6 +234,9 @@ class GrpcWrapperAsyncIO(IGrpcWrapperAsyncIO):
 
         except (grpc.RpcError, grpc.aio.AioRpcError) as e:
             raise connection._rpc_error_handler(self._connection_state, e)
+        except asyncio.CancelledError:
+            # gRPC CancelledError - convert to YDB error for retry logic
+            raise issues.ConnectionLost("gRPC stream cancelled")
 
         if not is_coordination_calls:
             issues._process_response(grpc_message)


### PR DESCRIPTION
asyncio.CancelledError from gRPC connection issues (e.g., YDB host downtime) was incorrectly treated as a fatal error, causing TopicWriter/TopicReader to stop instead of reconnecting.

The fix distinguishes between:
1. Intentional cancellation (close() called) - exit cleanly
2. gRPC connection issues - retry with backoff

Fixes #735

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
