### PR TITLE
Add llms.txt documentation support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.coverage',
     'sphinx_copybutton',
+    'sphinx_llms_txt',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -91,8 +92,17 @@ html_theme_options = {
 
 html_logo = '_static/logo.svg'
 html_favicon = '_static/logo.svg'
+html_baseurl = 'https://ydb-platform.github.io/ydb-python-sdk/'
 
 html_show_sourcelink = False
+
+llms_txt_title = 'YDB Python SDK Documentation'
+llms_txt_summary = '''
+Official Python client documentation for YDB, covering connection setup,
+authentication, query execution, topic messaging, table operations,
+coordination primitives, error handling, and API reference.
+'''
+llms_txt_uri_template = '{base_url}{docname}.html'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,15 @@ SDK is accessed through a ``Driver`` instance, so this page is the foundation fo
 everything else.
 
 
+LLM-ready Documentation
+-----------------------
+
+For AI-assisted coding, use `llms.txt <https://ydb-platform.github.io/ydb-python-sdk/llms.txt>`_
+as the documentation index and
+`llms-full.txt <https://ydb-platform.github.io/ydb-python-sdk/llms-full.txt>`_
+as the complete documentation context.
+
+
 Running Queries
 ---------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx_rtd_theme==2.0.0
 sphinx-copybutton==0.5.2
+sphinx-llms-txt==0.7.1


### PR DESCRIPTION
## What changed

- Added sphinx-llms-txt to documentation dependencies.
- Enabled sphinx_llms_txt in the Sphinx config.
- Configured generated llms.txt links to use the deployed GitHub Pages base URL.
- Added a short LLM-ready Documentation section to the docs landing page linking to llms.txt and llms-full.txt.

## Why

This publishes LLM-friendly documentation entry points similar to other Sphinx-based projects, while keeping links valid for the repository's GitHub Pages deployment path.