### PR TITLE
Move SLO report jobs to a workflow_run trigger

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -1,0 +1,48 @@
+name: slo-report
+
+# Runs in the base-repo context (not the fork's), so it has the
+# pull-requests: write permission needed to publish reports and edit
+# labels — which fork-triggered SLO runs do not.
+
+on:
+  workflow_run:
+    workflows: ["SLO"]
+    types:
+      - completed
+
+jobs:
+  publish-slo-report:
+    # SLO workflow runs on every PR event, but the job inside is gated
+    # on the "SLO" label. Without the label the matrix is skipped and the
+    # workflow conclusion is "skipped" — in that case there is nothing
+    # to publish and no label to remove.
+    if: github.event.workflow_run.conclusion != 'skipped'
+    name: Publish YDB SLO Report
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish YDB SLO Report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+
+  remove-slo-label:
+    if: github.event.workflow_run.conclusion != 'skipped'
+    name: Remove SLO Label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label from PR
+        env:
+          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR=$(jq -r '.[0].number' <<<"$PRS")
+          gh pr edit "$PR" --repo "$REPO" --remove-label SLO

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -125,35 +125,3 @@ jobs:
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline
           workload_baseline_command: ${{ matrix.sdk.command }}
-
-  publish-slo-report:
-    name: Publish YDB SLO Report
-    needs: ydb-slo-action
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Publish YDB SLO Report
-        uses: ydb-platform/ydb-slo-action/report@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_run_id: ${{ github.run_id }}
-
-  remove-slo-label:
-    if: always()
-    name: Remove SLO Label
-    needs: ydb-slo-action
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Remove SLO label from PR
-        env:
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh pr edit "$PR" --repo "$REPO" --remove-label SLO


### PR DESCRIPTION
## Summary
- Fork PRs trigger SLO with a read-only \`GITHUB_TOKEN\`, so the inline \`publish-slo-report\` / \`remove-slo-label\` jobs from #802 silently fail there.
- Extract both jobs into a separate \`slo-report.yml\` triggered via \`workflow_run\`. That handler runs in the base-repo context, so the token keeps \`pull-requests: write\`.
- Gate the jobs on \`workflow_run.conclusion != 'skipped'\` — when a PR has no \`SLO\` label, the SLO matrix is skipped, the workflow ends as \`skipped\`, and we don't try to publish a report or remove a label that was never there.

## Test plan
- [ ] Open a PR from a fork with the \`SLO\` label — report should publish, label should be removed after.
- [ ] Open a PR without the \`SLO\` label — slo-report workflow run should be skipped (no publish, no label edits).
- [ ] PR from a branch in the same repo with \`SLO\` — same as fork path.