### PR TITLE
Add code coverage measurement with Codecov integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,38 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto       # do not drop below the current level...
+        threshold: 1%      # ...by more than 1%
+    patch:
+      default:
+        target: 80%        # new/changed code in the PR diff must be >= 80% covered
+
+flags:
+  unit:
+    paths:
+      - ydb/
+    carryforward: true
+  integration:
+    paths:
+      - ydb/
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+# Auto-generated protobuf stubs and tests must not affect the metric.
+# Already excluded from coverage.xml via [tool.coverage.run] omit, listed here for safety.
+ignore:
+  - "ydb/_grpc/v3"
+  - "ydb/_grpc/v4"
+  - "ydb/_grpc/v5"
+  - "ydb/_grpc/v6"
+  - "ydb/dbapi"        # legacy
+  - "ydb/sqlalchemy"   # legacy
+  - "**/*_test.py"
+  - "tests"
+  - "examples"
+  - "docs"
+  - "benchmarks"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,3 +61,54 @@ jobs:
 
     - name: Run unit tests
       run: tox -e py -- ydb
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: coverage-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox==4.2.6
+
+    # sysmon (PEP 669) keeps tracer overhead low so timing-sensitive chaos
+    # tests (which kill/restart YDB) still pass under coverage. Requires py3.12+.
+    - name: Unit tests with coverage
+      env:
+        COVERAGE_CORE: sysmon
+      run: tox -e cov -- ydb
+
+    - name: Upload unit coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        flags: unit
+        name: unit
+        # The gate is enforced via Codecov status checks (branch protection),
+        # so don't fail CI on transient upload errors.
+        fail_ci_if_error: false
+
+    - name: Integration tests with coverage
+      env:
+        COVERAGE_CORE: sysmon
+      run: tox -e cov -- tests
+
+    - name: Upload integration coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        flags: integration
+        name: integration
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ ydb.egg-info/
 /ydb_data
 /tmp
 .coverage
+.coverage.*
 /cov_html
+/coverage.xml
 /build
 docs/_build
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ YDB Python SDK
 [![API Reference](https://img.shields.io/badge/API-Reference-lightgreen.svg)](https://ydb-platform.github.io/ydb-python-sdk)
 [![Functional tests](https://github.com/ydb-platform/ydb-python-sdk/actions/workflows/tests.yaml/badge.svg)](https://github.com/ydb-platform/ydb-python-sdk/actions/workflows/tests.yaml)
 [![Style checks](https://github.com/ydb-platform/ydb-python-sdk/actions/workflows/style.yaml/badge.svg)](https://github.com/ydb-platform/ydb-python-sdk/actions/workflows/style.yaml)
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-python-sdk/graph/badge.svg)](https://codecov.io/gh/ydb-platform/ydb-python-sdk)
 
 Officially supported Python client for YDB.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,29 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["ydb.types", "ydb.table"]
 disable_error_code = ["attr-defined"]
+
+[tool.coverage.run]
+branch = true
+source = ["ydb"]
+# Auto-generated protobuf stubs and test files must not skew the metric.
+omit = [
+    "ydb/_grpc/v3/*",
+    "ydb/_grpc/v4/*",
+    "ydb/_grpc/v5/*",
+    "ydb/_grpc/v6/*",
+    "*_test.py",
+    # Legacy, no longer actively developed.
+    "ydb/dbapi/*",
+    "ydb/sqlalchemy/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+]
+
+[tool.coverage.html]
+directory = "cov_html"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -44,6 +44,6 @@ pylint-protobuf
 cython
 freezegun>=1.3.0
 opentelemetry-sdk>=1.0.0
-# pytest-cov
+pytest-cov>=4.0.0
 yandexcloud
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,14 @@ deps =
     -r{toxinidir}/test-requirements.txt
     protobuf<6.0.0
 
+[testenv:cov]
+passenv = COVERAGE_CORE
+commands =
+    pytest -v --cov --cov-report=term-missing --cov-report=html --cov-report=xml {posargs}
+deps =
+    -r{toxinidir}/test-requirements.txt
+    protobuf<7.0.0
+
 [testenv:py-proto4]
 commands =
     pytest -v {posargs}


### PR DESCRIPTION
## Summary

Introduces code coverage measurement for the `ydb` package and wires it to Codecov with a PR gate.

- **Measurement:** `pytest-cov` (coverage.py) — branch coverage, `source=ydb`. Auto-generated `_grpc/v3..v6` stubs and `*_test.py` files are excluded; the hand-written `_grpc/grpcwrapper/*` (topic reader/writer logic) stays measured.
- **tox:** new `cov` env — `tox -e cov -- ydb` / `tox -e cov -- tests`, producing term/html/xml reports.
- **CI:** dedicated `coverage` job (Python 3.12) that runs the unit and integration suites and uploads both to Codecov with `unit` / `integration` flags (Codecov merges them).
- **Gate (`.github/codecov.yml`):** `project` coverage may not drop by more than 1%; new code in the diff (`patch`) must be ≥ 80% covered.
- **README:** Codecov badge.

## Baseline

Local combined run: **unit + integration = 81%** (605 passed, 18 pre-existing skips). Topic internals are well covered (reader/writer asyncio ~90%, `grpcwrapper/ydb_topic.py` 87%).

## Note on `COVERAGE_CORE=sysmon`

The coverage job uses the PEP 669 `sys.monitoring` backend. The default C tracer's overhead breaks the timing-sensitive chaos tests (e.g. `test_no_session_leak` does `acquire(timeout=0.5)` then asserts pool state and only restarts YDB *after* the assert — under tracer slowdown the assert fails, YDB stays down, and the rest of the suite cascades). `sysmon` keeps overhead low so these pass. It requires Python 3.12+, which is why coverage is collected on a single 3.12 job rather than across the whole matrix.

## Follow-up (after this PR runs green)

Add `codecov/project` and `codecov/patch` as **required status checks** in `main` branch protection to make the gate blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)