### PR TITLE
OpenTelemetry metrics support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@
 !requirements.txt
 !pyproject.toml
 !setup.py
+!examples/opentelemetry/requirements.txt
+!examples/opentelemetry/otel_example.py
+!examples/opentelemetry/load_tank.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Introduce `ydb.observability` — vendor-neutral tracing entrypoint with a `TracingProvider` interface; `enable_tracing(provider)` accepts any implementation (custom or OpenTelemetry) and replaces the previously installed one. The SDK core no longer imports `opentelemetry`, so tracing can be enabled without the OpenTelemetry packages by supplying a custom provider
 * When tracing is enabled the SDK appends a `ydb-sdk-tracing/0.1.0` token to the `x-ydb-sdk-build-info` header, so the server can distinguish requests from tracing-enabled clients
+* Add client-side metrics through the same vendor-neutral `ydb.observability` layer: `enable_metrics(provider)` / `disable_metrics()`, with `ydb.opentelemetry.enable_metrics(meter_provider=None)` as the OpenTelemetry convenience. Instruments cover client operation duration/failures, retry duration/attempts, and query session pool state. `QuerySessionPool` gains an optional `name` argument for the pool metric label. When metrics are enabled the SDK appends a `ydb-sdk-metrics/0.1.0` token to the `x-ydb-sdk-build-info` header
 
 ## 3.30.0 ##
 * Query session attach stream handles `NodeShutdown` and `SessionShutdown` session hints: on `NodeShutdown` the session's node connection is pessimized and the session is retired, on `SessionShutdown` the session is retired without touching the node

--- a/docs/observability.rst
+++ b/docs/observability.rst
@@ -8,9 +8,14 @@ driver initialization, and retries — are turned into spans and handed to which
 built-in backend (see :doc:`opentelemetry`), but any tracing system can be plugged in
 by implementing the interface described below.
 
-Tracing is **zero-cost when disabled**: until you install a provider every span is a
-no-op stub, and the SDK never imports ``opentelemetry`` — or any other backend — on its
-own. The dependency is pulled in only when you explicitly opt into a concrete provider.
+The same layer also exposes **client-side metrics** (operation latency and failures,
+retry cost, query session pool state) through :func:`ydb.observability.enable_metrics`.
+Tracing and metrics are independent — enable either, both, or neither.
+
+Observability is **zero-cost when disabled**: until you install a backend every span is a
+no-op stub and every metric is dropped by a no-op provider, and the SDK never imports
+``opentelemetry`` — or any other backend — on its own. The dependency is pulled in only
+when you explicitly opt into a concrete backend.
 
 
 The Tracing Interface
@@ -247,3 +252,163 @@ A custom ``attach_context`` must therefore honour this three-way contract on blo
 
 The ``LoggingSpan`` above already implements exactly this. Getting it wrong leaks spans
 (never ended) or ends them too early (streaming spans that miss the actual read time).
+
+
+Metrics
+-------
+
+Client-side metrics are enabled independently of tracing:
+
+.. code-block:: python
+
+    from ydb.observability import enable_metrics, disable_metrics
+
+    enable_metrics(provider)   # install a metrics backend
+    disable_metrics()          # turn metrics off — back to the no-op default
+
+For OpenTelemetry the built-in convenience is ``ydb.opentelemetry.enable_metrics``,
+which builds an OTel-backed provider from a meter provider and installs it here — see
+the :doc:`opentelemetry` page for the meter-provider and exporter setup.
+
+The Metrics Interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+A metrics backend implements :class:`~ydb.observability.MetricsProvider` — three
+methods, one per instrument kind:
+
+.. code-block:: python
+
+    class MetricsProvider(Protocol):
+        def record(self, name, value, attributes=None): ...       # value distribution (histogram)
+        def add(self, name, value, attributes=None): ...          # additive counter (may go negative)
+        def observe_gauge(self, name, callback): ...              # asynchronous gauge
+
+``record`` and ``add`` are pushed at the moment of the event. ``observe_gauge`` is
+different: the SDK owns the accumulated state (open sessions per pool, configured pool
+size) and hands the backend a ``callback`` that returns the current
+``(value, attributes)`` observations; the backend reads it whenever it collects. This
+keeps the pool bookkeeping vendor-neutral instead of pushing it into every backend.
+
+It is a :class:`typing.Protocol`, so a backend does **not** need to subclass anything —
+any object with these three methods works.
+
+Instruments
+~~~~~~~~~~~
+
+The SDK records the following instruments regardless of backend (the OpenTelemetry
+adapter maps them to instruments on the ``"ydb.sdk"`` meter):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 22 46
+
+   * - Metric
+     - Kind
+     - Description
+   * - ``db.client.operation.duration``
+     - Histogram (``s``)
+     - Latency of user-visible YDB client operations.
+   * - ``ydb.client.operation.failed``
+     - Counter
+     - Failed user-visible YDB client operations.
+   * - ``ydb.query.session.create_time``
+     - Histogram (``s``)
+     - Time spent creating a query session.
+   * - ``ydb.query.session.pending_requests``
+     - UpDownCounter
+     - Requests currently waiting for a session from the pool.
+   * - ``ydb.query.session.timeouts``
+     - Counter
+     - Session acquisition timeouts.
+   * - ``ydb.query.session.count``
+     - ObservableUpDownCounter
+     - Current number of open query sessions by pool and ``ydb.query.session.state`` (``idle`` / ``used``).
+   * - ``ydb.query.session.max``
+     - ObservableUpDownCounter
+     - Maximum configured number of sessions for a query session pool.
+   * - ``ydb.query.session.min``
+     - ObservableUpDownCounter
+     - Minimum configured pool size. The SDK sets no minimum, so this is always ``0``.
+   * - ``ydb.client.retry.duration``
+     - Histogram (``s``)
+     - Total duration of a logical retried operation, including attempts and backoff.
+   * - ``ydb.client.retry.attempts``
+     - Histogram
+     - Number of attempts performed for one logical retried operation.
+
+Attributes
+~~~~~~~~~~
+
+Operation metrics (``db.client.operation.*``) carry stable labels only:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Attribute
+     - Description
+   * - ``database``
+     - Database path.
+   * - ``endpoint``
+     - Configured endpoint in ``host:port`` form.
+   * - ``operation.name``
+     - SDK operation name without the ``ydb.`` prefix, e.g. ``"ExecuteQuery"``.
+   * - ``status_code``
+     - Added only to ``ydb.client.operation.failed``.
+
+Operation metrics are recorded for ``ExecuteQuery``, ``Commit``, ``Rollback``,
+``CreateSession`` and ``BeginTransaction``. Query session metrics use
+``ydb.query.session.pool.name``: when ``name`` is not passed to ``QuerySessionPool``
+the SDK falls back to the driver connection string ``<endpoint><database>`` (e.g.
+``grpc://localhost:2136/local``) so the pool is identifiable out of the box. Pass
+``QuerySessionPool(..., name="main-pool")`` (sync or async) when several pools share a
+connection string. Retry metrics are recorded without attributes.
+
+Writing a Custom Metrics Backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To send metrics somewhere OpenTelemetry does not cover — a home-grown collector, a log
+line, an in-memory recorder for tests — implement the three methods. Nothing to
+subclass; just match the signatures:
+
+.. code-block:: python
+
+    from ydb.observability import enable_metrics, disable_metrics
+
+
+    class LoggingMetrics:
+        def __init__(self):
+            self._gauges = {}
+
+        def record(self, name, value, attributes=None):
+            # A value distribution (histogram): operation/create/retry durations, attempts.
+            print(f"[metric] {name} = {value} {attributes or {}}")
+
+        def add(self, name, value, attributes=None):
+            # An additive counter; value may be negative (pending_requests goes up and down).
+            print(f"[metric] {name} += {value} {attributes or {}}")
+
+        def observe_gauge(self, name, callback):
+            # Asynchronous gauge: keep the callback and poll it whenever you collect.
+            # callback() -> iterable of (value, attributes).
+            self._gauges[name] = callback
+
+        def collect(self):
+            for name, callback in self._gauges.items():
+                for value, attributes in callback():
+                    print(f"[gauge] {name} = {value} {attributes}")
+
+
+    enable_metrics(LoggingMetrics())
+    # ... use the SDK; record()/add() fire as operations happen ...
+    disable_metrics()
+
+The instrument kind for each metric is implied by which method the SDK calls: names in
+the *Histogram* rows above arrive through ``record``, *Counter* / *UpDownCounter* names
+through ``add``, and the three *ObservableUpDownCounter* gauges
+(``ydb.query.session.count`` / ``max`` / ``min``) through ``observe_gauge``. A backend
+that has no notion of asynchronous gauges can simply store the callbacks (or ignore
+them); the SDK never pushes those values, so nothing is lost elsewhere.
+
+``disable_metrics()`` clears the SDK-side gauge state and reverts to the no-op default,
+so recording calls become cheap no-ops again.

--- a/docs/opentelemetry.rst
+++ b/docs/opentelemetry.rst
@@ -2,14 +2,17 @@ OpenTelemetry
 =============
 
 `OpenTelemetry <https://opentelemetry.io/>`_ is the built-in backend for the SDK's
-vendor-neutral tracing interface (see :doc:`observability`). Enabling it turns key YDB
-operations — session creation, query execution, transaction commit/rollback, driver
-initialization, and retries — into OpenTelemetry spans, and propagates trace context to
-the YDB server through gRPC metadata using the
-`W3C Trace Context <https://www.w3.org/TR/trace-context/>`_ standard.
+vendor-neutral observability interface (see :doc:`observability`). Enabling tracing turns
+key YDB operations — session creation, query execution, transaction commit/rollback,
+driver initialization, and retries — into OpenTelemetry spans, and propagates trace
+context to the YDB server through gRPC metadata using the
+`W3C Trace Context <https://www.w3.org/TR/trace-context/>`_ standard. Enabling metrics
+records client-side OpenTelemetry instruments for the same operations, retries, and
+query session pools.
 
 Like every backend, it is **zero-cost when disabled**: the SDK uses no-op stubs by
-default and does not import ``opentelemetry`` until you call ``enable_tracing()``.
+default and does not import ``opentelemetry`` until you call ``enable_tracing()`` or
+``enable_metrics()``.
 
 
 Installation
@@ -83,6 +86,52 @@ vendor-neutral entrypoint — this is exactly what the convenience wrapper above
     from ydb.opentelemetry import OtelTracingProvider
 
     enable_tracing(OtelTracingProvider())          # or OtelTracingProvider(my_tracer)
+
+
+Enabling Metrics
+----------------
+
+Metrics are independent from tracing — enable either or both. Call ``enable_metrics()``
+once, after configuring your OpenTelemetry meter provider and before creating drivers or
+query session pools:
+
+.. code-block:: python
+
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    import ydb
+    from ydb.opentelemetry import enable_metrics
+
+    # 1. Set up OpenTelemetry
+    resource = Resource(attributes={"service.name": "my-service"})
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint="http://localhost:4317"),
+        export_interval_millis=1000,
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+
+    # 2. Enable YDB metrics
+    enable_metrics(meter_provider)
+
+    # 3. Use the SDK as usual — metrics are recorded automatically
+    with ydb.Driver(endpoint="grpc://localhost:2136", database="/local") as driver:
+        driver.wait(timeout=5)
+        with ydb.QuerySessionPool(driver, name="main-pool") as pool:
+            pool.execute_with_retries("SELECT 1")
+
+    meter_provider.shutdown()
+
+``enable_metrics()`` accepts an optional ``meter_provider`` argument. If omitted, the SDK
+obtains a meter named ``"ydb.sdk"`` from the global meter provider. The call is
+idempotent: repeated ``enable_metrics()`` calls do nothing until you call
+``disable_metrics()``, which clears the in-memory observable metric values and restores
+the no-op provider so metric recording stays a cheap no-op.
+
+The full list of instruments and their attributes is catalogued on the
+:doc:`observability` page.
 
 
 Instrumented Spans and Attributes

--- a/examples/opentelemetry/Dockerfile
+++ b/examples/opentelemetry/Dockerfile
@@ -1,10 +1,12 @@
-# Isolated image for the OpenTelemetry demo. Build context is the repository root.
+# Isolated image for the OpenTelemetry demo scripts. Build context is the repository root.
 #
-#   docker compose -f examples/opentelemetry/compose-e2e.yaml build otel-example
+#   docker compose -f examples/opentelemetry/compose-e2e.yaml build
 #
 # A separate ``.dockerignore`` at the repo root keeps the context small.
 
 FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
@@ -15,7 +17,6 @@ COPY ydb ./ydb
 COPY examples/opentelemetry/requirements.txt ./examples/opentelemetry/requirements.txt
 RUN pip install --no-cache-dir -e '.[opentelemetry]' -r examples/opentelemetry/requirements.txt
 
-# Demo script.
+# Demo scripts.
 COPY examples/opentelemetry/otel_example.py ./examples/opentelemetry/otel_example.py
-
-CMD ["python", "examples/opentelemetry/otel_example.py"]
+COPY examples/opentelemetry/load_tank.py ./examples/opentelemetry/load_tank.py

--- a/examples/opentelemetry/README.md
+++ b/examples/opentelemetry/README.md
@@ -1,7 +1,15 @@
 # OpenTelemetry example (YDB Python SDK)
 
 Async demo in [`otel_example.py`](otel_example.py): OTLP export, `enable_tracing()`,
-`app_startup` and `example_tli` application spans, bank table, Serializable transactions (TLI-style load).
+`enable_metrics()`, `app_startup` and `example_tli` application spans, SDK client
+metrics, bank table, Serializable transactions (TLI-style load).
+
+[`load_tank.py`](load_tank.py) runs a small step-like load profile for the
+metrics dashboard:
+
+```text
+Peak RPS -> Medium RPS -> Min RPS -> Medium RPS -> repeat
+```
 
 Most steps assume the **repository root** as the current directory; the install step also shows the variant from this folder.
 
@@ -17,7 +25,10 @@ docker compose up -d
 # wait until the ydb container is healthy / port 2136 is open, then continue
 ```
 
-**Full stack** (YDB + OTLP collector + Tempo + Grafana; the `otel-example` service is built from a `Dockerfile` and runs the script once inside Compose). The compose file is `compose-e2e.yaml` next to this README.
+**Full stack** (YDB + OTLP collector + Tempo + Prometheus + Grafana; the
+`otel-example` service runs the tracing/metrics demo once, and `load-generator`
+runs the metrics load tank). The compose file is `compose-e2e.yaml` next to this
+README.
 
 ```sh
 cd /path/to/ydb-python-sdk
@@ -34,8 +45,28 @@ docker compose -f compose-e2e.yaml up --build
 The first run builds the `otel-example` image from the local SDK source (`Dockerfile` in this folder, `.dockerignore` at the repo root keeps the context small). Subsequent runs reuse the cached image; pass `--build` if you change the SDK or the demo script.
 
 Grafana: http://localhost:3000
+Prometheus: http://localhost:9090
+
+Grafana is provisioned with the **YDB Python SDK Metrics** dashboard. It uses
+Prometheus queries for SDK metrics such as `db_client_operation_duration`,
+`ydb_client_operation_failed`, `ydb_query_session_count`,
+`ydb_query_session_pending_requests`, `ydb_query_session_create_time`, and
+`ydb_client_retry_duration`. Use Grafana Explore for ad-hoc traces through Tempo
+and metrics through Prometheus.
+
+The SDK configures explicit OpenTelemetry histogram bucket boundaries for its
+own duration and retry-attempt metrics. Duration values are recorded in seconds,
+with sub-millisecond and millisecond-scale buckets so Grafana percentiles show
+meaningful latency distributions for fast local YDB operations.
+
+Metrics are wired through a dedicated SDK metrics plugin. Until `enable_metrics()`
+is called, the SDK uses a no-op metrics registry and does not import
+OpenTelemetry metrics packages from the hot-path metric helpers.
 
 **Logs for `otel-example`:** the container name is prefixed (e.g. `opentelemetry-otel-example-1`); use `docker compose -f examples/opentelemetry/compose-e2e.yaml ps` or `docker ps -a` to find it. The service is one-shot (`restart: "no"`) — it may already have exited.
+
+**Logs for `load-generator`:** the service is also one-shot. It runs for
+`LOAD_TANK_TOTAL_TIME` seconds and then exits after flushing metrics.
 
 ## 2. Install dependencies (on the host, for a local `python` run)
 
@@ -63,12 +94,37 @@ pip install -e '../..[opentelemetry]' -r requirements.txt
 python examples/opentelemetry/otel_example.py
 ```
 
-Defaults: YDB `grpc://localhost:2136`, OTLP `http://localhost:4317` (for a local collector, if you use one).
+Defaults: YDB `grpc://localhost:2136`, OTLP `http://localhost:4317` (for a local collector, if you use one). The same OTLP endpoint receives both traces and metrics.
+
+Run the load tank against an already running local stack:
+
+```sh
+python examples/opentelemetry/load_tank.py
+```
 
 ## Environment (Docker / overrides)
 
-| Variable | Meaning |
-|----------|---------|
-| `YDB_ENDPOINT` | e.g. `grpc://ydb:2136` inside the Compose network |
-| `YDB_DATABASE` | default `/local` |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | e.g. `http://otel-collector:4317` |
+| Variable | Meaning                                                  |
+|----------|----------------------------------------------------------|
+| `YDB_ENDPOINT` | e.g. `grpc://ydb:2136` inside the Compose network        |
+| `YDB_DATABASE` | default `/local`                                         |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | e.g. `http://otel-collector:4317`                        |
+| `OTEL_SERVICE_NAME` | service name attached to exported telemetry              |
+| `LOAD_TANK_TOTAL_TIME` | total load duration in seconds, default `6000`           |
+| `LOAD_TANK_WORKERS` | number of concurrent workers, default `40`               |
+| `LOAD_TANK_POOL_SIZE` | query session pool size, default `20`                    |
+| `LOAD_TANK_PEAK_RPS` | peak phase target RPS, default `120`                     |
+| `LOAD_TANK_MEDIUM_RPS` | medium phase target RPS, default `30`                    |
+| `LOAD_TANK_MIN_RPS` | low phase target RPS, default `3`                        |
+| `LOAD_TANK_ERROR_RPS` | failed query target RPS, default `1`; set `0` to disable |
+| `LOAD_TANK_PRESSURE_POOL_SIZE` | pool size for session pressure metrics, default `1`      |
+| `LOAD_TANK_PRESSURE_WORKERS` | concurrent contenders for the pressure pool, default `8` |
+| `LOAD_TANK_PRESSURE_HOLD_TIME` | seconds to hold the pressure-pool session, default `1.5` |
+| `LOAD_TANK_PRESSURE_ACQUIRE_TIMEOUT` | short acquire timeout for timeout metrics, default `1.0` |
+| `LOAD_TANK_PRESSURE_INTERVAL` | pause between pressure rounds, default `0.2`             |
+| `LOAD_TANK_SESSION_CHURN_INTERVAL` | interval for creating fresh sessions, default `2.0`      |
+| `LOAD_TANK_PEAK_DURATION` | peak phase duration in seconds, default `60`             |
+| `LOAD_TANK_MEDIUM_DURATION` | medium phase duration in seconds, default `90`           |
+| `LOAD_TANK_MIN_DURATION` | low phase duration in seconds, default `60`              |
+| `LOAD_TANK_QUERY` | query executed by workers, default `SELECT 1 AS value`   |
+| `LOAD_TANK_ERROR_QUERY` | query used to produce failed-operation metrics           |

--- a/examples/opentelemetry/compose-e2e.yaml
+++ b/examples/opentelemetry/compose-e2e.yaml
@@ -1,5 +1,5 @@
 # Full OpenTelemetry demo: YDB (server-side tracing config), collector, Tempo, Prometheus, Grafana,
-# and a one-shot container that runs otel_example.py once.
+# a one-shot container that runs otel_example.py once, and a load generator for live metrics.
 #
 # Run from this directory (paths below are relative to this file):
 #   cd examples/opentelemetry && docker compose -f compose-e2e.yaml up
@@ -78,11 +78,42 @@ services:
     build:
       context: ../..
       dockerfile: examples/opentelemetry/Dockerfile
+    command: ["python", "examples/opentelemetry/otel_example.py"]
     environment:
       YDB_ENDPOINT: grpc://ydb:2136
       YDB_DATABASE: /local
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_SERVICE_NAME: ydb-otel-example
+    depends_on:
+      ydb:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    restart: "no"
+
+  load-generator:
+    build:
+      context: ../..
+      dockerfile: examples/opentelemetry/Dockerfile
+    command: ["python", "examples/opentelemetry/load_tank.py"]
+    environment:
+      YDB_ENDPOINT: grpc://ydb:2136
+      YDB_DATABASE: /local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_SERVICE_NAME: ydb-python-load-tank
+      LOAD_TANK_TOTAL_TIME: "6000"
+      LOAD_TANK_WORKERS: "40"
+      LOAD_TANK_POOL_SIZE: "20"
+      LOAD_TANK_PEAK_RPS: "120"
+      LOAD_TANK_MEDIUM_RPS: "30"
+      LOAD_TANK_MIN_RPS: "3"
+      LOAD_TANK_ERROR_RPS: "1"
+      LOAD_TANK_PRESSURE_POOL_SIZE: "1"
+      LOAD_TANK_PRESSURE_WORKERS: "8"
+      LOAD_TANK_PRESSURE_HOLD_TIME: "1.5"
+      LOAD_TANK_PRESSURE_ACQUIRE_TIMEOUT: "1.0"
+      LOAD_TANK_PRESSURE_INTERVAL: "0.2"
+      LOAD_TANK_SESSION_CHURN_INTERVAL: "2.0"
     depends_on:
       ydb:
         condition: service_healthy

--- a/examples/opentelemetry/grafana/dashboards/README.md
+++ b/examples/opentelemetry/grafana/dashboards/README.md
@@ -1,5 +1,7 @@
-This folder is intentionally left empty.
+This folder contains Grafana dashboards provisioned by the local OpenTelemetry example.
 
-Grafana is provisioned with Tempo + Prometheus datasources; use **Explore** to search traces.
+`ydb-python-sdk-metrics.json` shows the YDB Python SDK metrics exported to Prometheus,
+including client operation latency, failures, query session pool usage, pool min/max,
+pending session requests, acquisition timeouts, and retry metrics.
 
 

--- a/examples/opentelemetry/grafana/dashboards/ydb-python-sdk-metrics.json
+++ b/examples/opentelemetry/grafana/dashboards/ydb-python-sdk-metrics.json
@@ -1,0 +1,191 @@
+{
+  "title": "YDB Python SDK Metrics",
+  "uid": "ydb-python-sdk-metrics",
+  "schemaVersion": 38,
+  "timezone": "browser",
+  "refresh": "5s",
+  "tags": ["ydb", "python", "opentelemetry"],
+  "panels": [
+    {
+      "title": "Request Rate (RPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (ydb_operation_name) (rate(db_client_operation_duration_seconds_count[$__rate_interval]))",
+          "legendFormat": "{{ydb_operation_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Error Rate (RPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (db_response_status_code) (rate(ydb_client_operation_failed_total[$__rate_interval]))",
+          "legendFormat": "{{db_response_status_code}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Query Session Pool (Used / Idle)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (ydb_query_session_count{ydb_query_session_state=\"used\"})",
+          "legendFormat": "used - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (ydb_query_session_count{ydb_query_session_state=\"idle\"})",
+          "legendFormat": "idle - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (ydb_query_session_max)",
+          "legendFormat": "max - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (ydb_query_session_min)",
+          "legendFormat": "min - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Pending Session Requests",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (ydb_query_session_pending_requests)",
+          "legendFormat": "{{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Session Acquire Timeouts",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (ydb_query_session_pool_name) (increase(ydb_query_session_timeouts_total[$__rate_interval]))",
+          "legendFormat": "{{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Operation Latency Percentiles",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, ydb_operation_name) (rate(db_client_operation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 - {{ydb_operation_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, ydb_operation_name) (rate(db_client_operation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 - {{ydb_operation_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, ydb_operation_name) (rate(db_client_operation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 - {{ydb_operation_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Session Create Time Percentiles",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, ydb_query_session_pool_name) (rate(ydb_query_session_create_time_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, ydb_query_session_pool_name) (rate(ydb_query_session_create_time_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, ydb_query_session_pool_name) (rate(ydb_query_session_create_time_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 - {{ydb_query_session_pool_name}}",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Retry Duration Percentiles",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ydb_client_retry_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(ydb_client_retry_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ydb_client_retry_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    },
+    {
+      "title": "Retry Attempts",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum(rate(ydb_client_retry_attempts_sum[$__rate_interval])) / sum(rate(ydb_client_retry_attempts_count[$__rate_interval]))",
+          "legendFormat": "avg attempts",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "sum(rate(ydb_client_retry_attempts_count[$__rate_interval])) - sum(rate(ydb_client_retry_attempts_bucket{le=\"1\"}[$__rate_interval]))",
+          "legendFormat": "retried operations rps",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "expr": "(sum(rate(ydb_client_retry_attempts_count[$__rate_interval])) - sum(rate(ydb_client_retry_attempts_bucket{le=\"1\"}[$__rate_interval]))) / sum(rate(ydb_client_retry_attempts_count[$__rate_interval]))",
+          "legendFormat": "retried operations ratio",
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/opentelemetry/grafana/provisioning/datasources/datasources.yaml
+++ b/examples/opentelemetry/grafana/provisioning/datasources/datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
@@ -10,13 +11,14 @@ datasources:
 
   - name: Tempo
     type: tempo
+    uid: tempo
     access: proxy
     url: http://tempo:3200
     editable: false
     jsonData:
       tracesToMetrics:
-        datasourceUid: Prometheus
+        datasourceUid: prometheus
       serviceMap:
-        datasourceUid: Prometheus
+        datasourceUid: prometheus
 
 

--- a/examples/opentelemetry/load_tank.py
+++ b/examples/opentelemetry/load_tank.py
@@ -1,0 +1,287 @@
+"""Small OpenTelemetry load generator for the YDB Python SDK example."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+import time
+from dataclasses import dataclass
+from typing import AsyncIterator, Tuple
+
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+
+import ydb
+from ydb.opentelemetry import enable_metrics
+
+
+@dataclass(frozen=True)
+class LoadConfig:
+    endpoint: str
+    database: str
+    otlp_endpoint: str
+    service_name: str
+    pool_size: int
+    worker_count: int
+    peak_rps: int
+    medium_rps: int
+    min_rps: int
+    peak_duration: int
+    medium_duration: int
+    min_duration: int
+    total_time: int
+    query: str
+    error_rps: int
+    error_query: str
+    pressure_pool_size: int
+    pressure_workers: int
+    pressure_hold_time: float
+    pressure_acquire_timeout: float
+    pressure_interval: float
+    session_churn_interval: float
+
+
+def _env(name: str, default: str) -> str:
+    value = os.environ.get(name)
+    return value if value is not None and value != "" else default
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(_env(name, str(default)))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(_env(name, str(default)))
+
+
+def _load_config() -> LoadConfig:
+    return LoadConfig(
+        endpoint=_env("YDB_ENDPOINT", "grpc://localhost:2136"),
+        database=_env("YDB_DATABASE", "/local"),
+        otlp_endpoint=_env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+        service_name=_env("OTEL_SERVICE_NAME", "ydb-python-load-tank"),
+        pool_size=_env_int("LOAD_TANK_POOL_SIZE", 20),
+        worker_count=_env_int("LOAD_TANK_WORKERS", 40),
+        peak_rps=_env_int("LOAD_TANK_PEAK_RPS", 120),
+        medium_rps=_env_int("LOAD_TANK_MEDIUM_RPS", 30),
+        min_rps=_env_int("LOAD_TANK_MIN_RPS", 3),
+        peak_duration=_env_int("LOAD_TANK_PEAK_DURATION", 60),
+        medium_duration=_env_int("LOAD_TANK_MEDIUM_DURATION", 90),
+        min_duration=_env_int("LOAD_TANK_MIN_DURATION", 60),
+        total_time=_env_int("LOAD_TANK_TOTAL_TIME", 300),
+        query=_env("LOAD_TANK_QUERY", "SELECT 1 AS value"),
+        error_rps=_env_int("LOAD_TANK_ERROR_RPS", 1),
+        error_query=_env("LOAD_TANK_ERROR_QUERY", "SELECT * FROM table_that_does_not_exist_for_metrics"),
+        pressure_pool_size=_env_int("LOAD_TANK_PRESSURE_POOL_SIZE", 1),
+        pressure_workers=_env_int("LOAD_TANK_PRESSURE_WORKERS", 8),
+        pressure_hold_time=_env_float("LOAD_TANK_PRESSURE_HOLD_TIME", 1.5),
+        pressure_acquire_timeout=_env_float("LOAD_TANK_PRESSURE_ACQUIRE_TIMEOUT", 1.0),
+        pressure_interval=_env_float("LOAD_TANK_PRESSURE_INTERVAL", 0.2),
+        session_churn_interval=_env_float("LOAD_TANK_SESSION_CHURN_INTERVAL", 2.0),
+    )
+
+
+async def _load_steps(config: LoadConfig) -> AsyncIterator[Tuple[int, str, int]]:
+    pattern = (
+        (config.peak_rps, "Peak", config.peak_duration),
+        (config.medium_rps, "Medium down", config.medium_duration),
+        (config.min_rps, "Min", config.min_duration),
+        (config.medium_rps, "Medium up", config.medium_duration),
+    )
+    deadline = time.monotonic() + config.total_time
+
+    while time.monotonic() < deadline:
+        for rps, label, duration in pattern:
+            remaining = int(deadline - time.monotonic())
+            if remaining <= 0:
+                return
+            yield rps, label, min(duration, remaining)
+
+
+async def _worker(
+    pool: ydb.aio.QuerySessionPool,
+    queue: asyncio.Queue[object],
+    query: str,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(queue.get(), timeout=0.5)
+        except asyncio.TimeoutError:
+            continue
+
+        try:
+            await pool.execute_with_retries(query)
+        except Exception as exc:
+            print("Load operation failed: %s" % exc)
+        finally:
+            queue.task_done()
+
+
+async def _feed_phase(queue: asyncio.Queue[object], rps: int, duration: int) -> None:
+    interval = 1.0 / max(rps, 1)
+    deadline = time.monotonic() + duration
+    next_tick = time.monotonic()
+
+    while time.monotonic() < deadline:
+        await queue.put(object())
+        next_tick += interval
+        delay = next_tick - time.monotonic()
+        if delay > 0:
+            await asyncio.sleep(delay)
+        else:
+            await asyncio.sleep(0)
+
+
+async def _error_worker(pool: ydb.aio.QuerySessionPool, config: LoadConfig, stop: asyncio.Event) -> None:
+    if config.error_rps <= 0:
+        return
+
+    interval = 1.0 / config.error_rps
+    next_tick = time.monotonic()
+
+    while not stop.is_set():
+        try:
+            await pool.execute_with_retries(config.error_query)
+        except Exception:
+            pass
+
+        next_tick += interval
+        delay = next_tick - time.monotonic()
+        if delay > 0:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=delay)
+            except asyncio.TimeoutError:
+                pass
+        else:
+            await asyncio.sleep(0)
+
+
+async def _pressure_round(pool: ydb.aio.QuerySessionPool, config: LoadConfig) -> None:
+    async def holder() -> None:
+        async with pool.checkout(timeout=5):
+            await asyncio.sleep(config.pressure_hold_time)
+
+    async def contender() -> None:
+        try:
+            async with pool.checkout(timeout=config.pressure_acquire_timeout):
+                pass
+        except Exception:
+            pass
+
+    holder_task = asyncio.create_task(holder())
+    await asyncio.sleep(0)
+    contenders = [asyncio.create_task(contender()) for _ in range(config.pressure_workers)]
+    await asyncio.gather(holder_task, *contenders, return_exceptions=True)
+
+
+async def _pool_pressure_worker(driver: ydb.aio.Driver, config: LoadConfig, stop: asyncio.Event) -> None:
+    if config.pressure_workers <= 0 or config.pressure_pool_size <= 0:
+        return
+
+    async with ydb.aio.QuerySessionPool(
+        driver,
+        size=config.pressure_pool_size,
+        name="pool-pressure",
+    ) as pool:
+        while not stop.is_set():
+            await _pressure_round(pool, config)
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=config.pressure_interval)
+            except asyncio.TimeoutError:
+                pass
+
+
+async def _session_churn_worker(driver: ydb.aio.Driver, config: LoadConfig, stop: asyncio.Event) -> None:
+    if config.session_churn_interval <= 0:
+        return
+
+    while not stop.is_set():
+        async with ydb.aio.QuerySessionPool(driver, size=1, name="session-churn") as pool:
+            await pool.execute_with_retries("SELECT 1 AS value")
+
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=config.session_churn_interval)
+        except asyncio.TimeoutError:
+            pass
+
+
+async def main() -> None:
+    config = _load_config()
+
+    resource = Resource(attributes={"service.name": config.service_name})
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=config.otlp_endpoint),
+        export_interval_millis=2000,
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    enable_metrics(meter_provider)
+
+    print(
+        "=== YDB Python SDK load tank ===\n"
+        "    total=%ss workers=%s pool_size=%s query=%r error_rps=%s\n"
+        "    pressure_pool_size=%s pressure_workers=%s pressure_timeout=%ss session_churn_interval=%ss\n"
+        "    pattern: Peak(%s rps, %ss) -> Medium(%s rps, %ss) -> "
+        "Min(%s rps, %ss) -> Medium -> repeat"
+        % (
+            config.total_time,
+            config.worker_count,
+            config.pool_size,
+            config.query,
+            config.error_rps,
+            config.pressure_pool_size,
+            config.pressure_workers,
+            config.pressure_acquire_timeout,
+            config.session_churn_interval,
+            config.peak_rps,
+            config.peak_duration,
+            config.medium_rps,
+            config.medium_duration,
+            config.min_rps,
+            config.min_duration,
+        )
+    )
+
+    async with ydb.aio.Driver(
+        endpoint=config.endpoint,
+        database=config.database,
+        disable_discovery=True,
+    ) as driver:
+        await driver.wait(timeout=60)
+
+        async with ydb.aio.QuerySessionPool(driver, size=config.pool_size, name="load-tank") as pool:
+            queue: asyncio.Queue[object] = asyncio.Queue(maxsize=max(config.worker_count * 4, config.peak_rps))
+            stop = asyncio.Event()
+            workers = [
+                asyncio.create_task(_worker(pool, queue, config.query, stop)) for _ in range(config.worker_count)
+            ]
+            error_task = asyncio.create_task(_error_worker(pool, config, stop))
+            pressure_task = asyncio.create_task(_pool_pressure_worker(driver, config, stop))
+            churn_task = asyncio.create_task(_session_churn_worker(driver, config, stop))
+
+            try:
+                async for rps, label, duration in _load_steps(config):
+                    print("[%s] Phase: %s (%s RPS for %ss)" % (time.strftime("%H:%M:%S"), label, rps, duration))
+                    await _feed_phase(queue, rps, duration)
+                    await asyncio.sleep(random.random() / 10.0)
+
+                await queue.join()
+            finally:
+                stop.set()
+                for worker in workers:
+                    worker.cancel()
+                error_task.cancel()
+                pressure_task.cancel()
+                churn_task.cancel()
+                await asyncio.gather(*workers, error_task, pressure_task, churn_task, return_exceptions=True)
+
+    print("Waiting 10s to flush metrics...")
+    await asyncio.sleep(10)
+    meter_provider.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/opentelemetry/otel_example.py
+++ b/examples/opentelemetry/otel_example.py
@@ -8,8 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.export import PeriodicExportingMetricReader
+
 import ydb
-from ydb.opentelemetry import enable_tracing
+from ydb.opentelemetry import enable_metrics, enable_tracing
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -45,12 +50,19 @@ async def main() -> None:
     otlp_endpoint = _env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
     resource = Resource(attributes={"service.name": _env("OTEL_SERVICE_NAME", "ydb-otel-example")})
-    provider = TracerProvider(resource=resource)
-    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint)))
-    trace.set_tracer_provider(provider)
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint)))
+    trace.set_tracer_provider(tracer_provider)
 
     tracer = trace.get_tracer(__name__)
     enable_tracing(tracer)
+
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=otlp_endpoint),
+        export_interval_millis=1000,
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    enable_metrics(meter_provider)
 
     async with ydb.aio.Driver(
         endpoint=endpoint,
@@ -84,8 +96,10 @@ async def main() -> None:
             final_rows = await pool.execute_with_retries("SELECT amount FROM bank WHERE id = 1")
             amount = int(list(final_rows[0].rows)[0]["amount"])
             print(f"Final amount (after serializable retries): {amount}")
-
-    provider.shutdown()
+    print("Application will shut down in 15 seconds...")
+    await asyncio.sleep(15)
+    tracer_provider.shutdown()
+    meter_provider.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -7,6 +7,10 @@ can be collected and inspected without any external backend.
 import pytest
 
 from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics import Counter, Histogram, ObservableUpDownCounter, UpDownCounter
+from opentelemetry.sdk.metrics.export import AggregationTemporality
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -35,6 +39,30 @@ def otel_setup():
     # Restore noop state
     disable_tracing()
     _exporter.clear()
+
+
+@pytest.fixture()
+def metrics_setup():
+    """Enable SDK metrics with an in-memory reader, then restore noop defaults."""
+    from ydb.opentelemetry import disable_metrics, enable_metrics
+
+    reader = InMemoryMetricReader(
+        preferred_temporality={
+            Counter: AggregationTemporality.CUMULATIVE,
+            Histogram: AggregationTemporality.CUMULATIVE,
+            ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+            UpDownCounter: AggregationTemporality.CUMULATIVE,
+        }
+    )
+    provider = MeterProvider(metric_readers=[reader])
+
+    disable_metrics()
+    enable_metrics(provider)
+    try:
+        yield reader
+    finally:
+        disable_metrics()
+        provider.shutdown()
 
 
 class FakeDriverConfig:

--- a/tests/observability/test_metrics.py
+++ b/tests/observability/test_metrics.py
@@ -1,0 +1,1030 @@
+import inspect
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from opentelemetry.metrics import Meter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+
+def _metrics_by_name(reader):
+    data = reader.get_metrics_data()
+    if data is None:
+        return {}
+
+    return {
+        metric.name: metric
+        for resource_metrics in data.resource_metrics
+        for scope_metrics in resource_metrics.scope_metrics
+        for metric in scope_metrics.metrics
+    }
+
+
+def _single_point(reader, name):
+    return _single_point_from_metrics(_metrics_by_name(reader), name)
+
+
+def _single_point_from_metrics(metrics, name):
+    metric = metrics[name]
+    points = list(metric.data.data_points)
+    assert len(points) == 1
+    return points[0]
+
+
+def _points(reader, name):
+    metrics = _metrics_by_name(reader)
+    if name not in metrics:
+        return []
+    return list(metrics[name].data.data_points)
+
+
+def _histogram_sum(reader, name):
+    return _single_point(reader, name).sum
+
+
+def _sum_value(reader, name):
+    return _single_point(reader, name).value
+
+
+def _histogram_boundaries_advisory_supported():
+    return "explicit_bucket_boundaries_advisory" in inspect.signature(Meter.create_histogram).parameters
+
+
+def test_metrics_registry_records_all_instruments(metrics_setup, monkeypatch):
+    from ydb import issues
+    from ydb.observability.metrics import (
+        CLIENT_OPERATION_DURATION,
+        CLIENT_OPERATION_FAILED,
+        QUERY_SESSION_COUNT,
+        QUERY_SESSION_CREATE_TIME,
+        QUERY_SESSION_MAX,
+        QUERY_SESSION_MIN,
+        QUERY_SESSION_PENDING_REQUESTS,
+        QUERY_SESSION_TIMEOUTS,
+        RETRY_ATTEMPTS,
+        RETRY_DURATION,
+        ATTEMPT_BUCKETS,
+        DURATION_BUCKETS_SECONDS,
+        RETRY_DURATION_BUCKETS_SECONDS,
+        create_metrics_operation,
+        record_query_session_count,
+        record_query_session_create_time,
+        record_query_session_max,
+        record_query_session_pending_requests,
+        record_query_session_timeout,
+        record_retry_metrics,
+    )
+
+    monkeypatch.setattr("ydb.observability.metrics.time.monotonic", MagicMock(side_effect=[1.0, 1.25]))
+
+    with pytest.raises(issues.Unavailable):
+        with create_metrics_operation("ExecuteQuery"):
+            raise issues.Unavailable("transient")
+
+    record_query_session_count(2, "main", "used")
+    record_query_session_create_time(0.5, "main")
+    record_query_session_max(100, "main")
+    record_query_session_pending_requests(1, "main")
+    record_query_session_timeout("main")
+    record_retry_metrics(0.75, 3)
+
+    metrics = _metrics_by_name(metrics_setup)
+
+    assert set(metrics) == {
+        CLIENT_OPERATION_DURATION,
+        CLIENT_OPERATION_FAILED,
+        QUERY_SESSION_COUNT,
+        QUERY_SESSION_CREATE_TIME,
+        QUERY_SESSION_MAX,
+        QUERY_SESSION_MIN,
+        QUERY_SESSION_PENDING_REQUESTS,
+        QUERY_SESSION_TIMEOUTS,
+        RETRY_ATTEMPTS,
+        RETRY_DURATION,
+    }
+    assert metrics[CLIENT_OPERATION_DURATION].unit == "s"
+    assert metrics[CLIENT_OPERATION_FAILED].unit == "{command}"
+    assert metrics[QUERY_SESSION_COUNT].unit == "{connection}"
+    assert metrics[QUERY_SESSION_CREATE_TIME].unit == "s"
+    assert metrics[QUERY_SESSION_MAX].unit == "{connection}"
+    assert metrics[QUERY_SESSION_MIN].unit == "{connection}"
+    assert metrics[QUERY_SESSION_PENDING_REQUESTS].unit == "{request}"
+    assert metrics[QUERY_SESSION_TIMEOUTS].unit == "{connection}"
+    assert metrics[RETRY_DURATION].unit == "s"
+    assert metrics[RETRY_ATTEMPTS].unit == "{attempt}"
+    if _histogram_boundaries_advisory_supported():
+        assert (
+            _single_point_from_metrics(metrics, CLIENT_OPERATION_DURATION).explicit_bounds == DURATION_BUCKETS_SECONDS
+        )
+        assert (
+            _single_point_from_metrics(metrics, QUERY_SESSION_CREATE_TIME).explicit_bounds == DURATION_BUCKETS_SECONDS
+        )
+        assert _single_point_from_metrics(metrics, RETRY_DURATION).explicit_bounds == RETRY_DURATION_BUCKETS_SECONDS
+        assert _single_point_from_metrics(metrics, RETRY_ATTEMPTS).explicit_bounds == ATTEMPT_BUCKETS
+
+
+def test_metrics_registry_supports_old_histogram_api():
+    from ydb.opentelemetry.metrics_plugin import OtelMetricsProvider
+
+    class FakeInstrument:
+        def add(self, value, attributes=None):
+            pass
+
+        def record(self, value, attributes=None):
+            pass
+
+    class FakeMeter:
+        def create_histogram(self, name, unit="", description="", **kwargs):
+            if "explicit_bucket_boundaries_advisory" in kwargs:
+                raise TypeError(
+                    "create_histogram() got an unexpected keyword argument 'explicit_bucket_boundaries_advisory'"
+                )
+            return FakeInstrument()
+
+        def create_counter(self, name, unit="", description=""):
+            return FakeInstrument()
+
+        def create_up_down_counter(self, name, unit="", description=""):
+            return FakeInstrument()
+
+        def create_observable_up_down_counter(self, name, callbacks=None, unit="", description=""):
+            return FakeInstrument()
+
+    OtelMetricsProvider(FakeMeter())
+
+
+def test_create_histogram_reraises_unrelated_type_error():
+    from ydb.opentelemetry.metrics_plugin import _create_histogram
+
+    class BrokenMeter:
+        def create_histogram(self, name, unit="", description="", **kwargs):
+            raise TypeError("unexpected unit type")
+
+    with pytest.raises(TypeError, match="unexpected unit type"):
+        _create_histogram(
+            BrokenMeter(),
+            "test.histogram",
+            unit="s",
+            description="test",
+            bucket_boundaries=[1.0],
+        )
+
+
+def test_metrics_registry_is_noop_without_meter():
+    from ydb.observability.metrics import (
+        create_metrics_operation,
+        record_query_session_create_time,
+        record_query_session_max,
+        record_query_session_pending_requests,
+        record_query_session_timeout,
+        record_retry_metrics,
+        remove_query_session_pool_metrics,
+    )
+
+    record_query_session_create_time(1.0, "pool")
+    record_query_session_max(10, "pool")
+    record_query_session_pending_requests(1, "pool")
+    record_query_session_timeout("pool")
+    record_retry_metrics(1.0, 2)
+    remove_query_session_pool_metrics("pool")
+
+    operation = create_metrics_operation("ExecuteQuery")
+    operation.set_error(ValueError("noop"))
+    operation.set_attribute("database", "/db")
+    with operation:
+        pass
+
+
+def test_metrics_operation_records_duration_once(metrics_setup, monkeypatch):
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION, create_metrics_operation
+
+    monotonic = MagicMock(side_effect=[10.0, 10.25, 11.0])
+    monkeypatch.setattr("ydb.observability.metrics.time.monotonic", monotonic)
+
+    operation = create_metrics_operation(
+        "ExecuteQuery",
+        {
+            "database": "/Root/test",
+            "endpoint": "localhost:2136",
+        },
+    )
+    operation.end()
+    operation.end()
+
+    point = _single_point(metrics_setup, CLIENT_OPERATION_DURATION)
+
+    assert point.sum == 0.25
+    assert point.count == 1
+    assert point.attributes == {
+        "database": "/Root/test",
+        "endpoint": "localhost:2136",
+        "operation.name": "ExecuteQuery",
+    }
+
+
+def test_metrics_operation_records_ydb_error(metrics_setup, monkeypatch):
+    from ydb import issues
+    from ydb.observability.metrics import CLIENT_OPERATION_FAILED, create_metrics_operation
+
+    monkeypatch.setattr("ydb.observability.metrics.time.monotonic", MagicMock(side_effect=[1.0, 1.1]))
+
+    with pytest.raises(issues.Unavailable):
+        with create_metrics_operation("ExecuteQuery"):
+            raise issues.Unavailable("transient")
+
+    point = _single_point(metrics_setup, CLIENT_OPERATION_FAILED)
+
+    assert point.value == 1
+    assert point.attributes["status_code"] == "UNAVAILABLE"
+    assert point.attributes["operation.name"] == "ExecuteQuery"
+
+
+def test_metrics_operation_records_generic_error_status_code(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_FAILED, create_metrics_operation
+
+    with pytest.raises(ValueError):
+        with create_metrics_operation("ExecuteQuery"):
+            raise ValueError("bad value")
+
+    assert _single_point(metrics_setup, CLIENT_OPERATION_FAILED).attributes["status_code"] == "ValueError"
+
+
+def test_metrics_operation_set_attribute(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION, create_metrics_operation
+
+    operation = create_metrics_operation("ExecuteQuery")
+    operation.set_attribute("database", "/Root/test")
+    operation.end()
+
+    assert _single_point(metrics_setup, CLIENT_OPERATION_DURATION).attributes["database"] == "/Root/test"
+
+
+def test_metrics_operation_ignores_non_metric_attributes(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION, create_metrics_operation
+
+    operation = create_metrics_operation("ExecuteQuery")
+    operation.set_attribute("db.namespace", "/Root/test")
+    operation.set_attribute("server.address", "localhost")
+    operation.set_attribute("server.port", 2136)
+    operation.set_attribute("ydb.operation.name", "ydb.Commit")
+    operation.set_attribute("network.peer.address", "node.example.net")
+    operation.set_attribute("network.peer.port", 2136)
+    operation.set_attribute("ydb.node.dc", "dc-a")
+    operation.set_attribute("ydb.node.id", 123)
+    operation.end()
+
+    attrs = _single_point(metrics_setup, CLIENT_OPERATION_DURATION).attributes
+
+    assert "db.namespace" not in attrs
+    assert "server.address" not in attrs
+    assert "server.port" not in attrs
+    assert "ydb.operation.name" not in attrs
+    assert "network.peer.address" not in attrs
+    assert "network.peer.port" not in attrs
+    assert "ydb.node.dc" not in attrs
+    assert "ydb.node.id" not in attrs
+
+
+def test_metrics_operation_respects_end_on_exit_false(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION, create_metrics_operation
+
+    operation = create_metrics_operation("ExecuteQuery")
+    with operation.attach_context(end_on_exit=False):
+        pass
+
+    assert CLIENT_OPERATION_DURATION not in _metrics_by_name(metrics_setup)
+
+    operation.end()
+
+    point = _single_point(metrics_setup, CLIENT_OPERATION_DURATION)
+    assert point.count == 1
+    assert point.sum >= 0
+
+
+def test_metrics_operation_context_records_error_on_exit(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_FAILED, create_metrics_operation
+
+    operation = create_metrics_operation("ExecuteQuery")
+    with pytest.raises(RuntimeError, match="boom"):
+        with operation.attach_context():
+            raise RuntimeError("boom")
+
+    assert _single_point(metrics_setup, CLIENT_OPERATION_FAILED).attributes["status_code"] == "RuntimeError"
+
+
+def test_metrics_operation_ignores_unknown_operation_name(metrics_setup):
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION, create_metrics_operation
+
+    with create_metrics_operation("ydb.Driver.Initialize"):
+        pass
+
+    assert CLIENT_OPERATION_DURATION not in _metrics_by_name(metrics_setup)
+
+
+def test_create_ydb_span_records_metrics_when_tracing_is_active(metrics_setup, otel_setup):
+    from tests.observability.conftest import FakeDriverConfig
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION
+    from ydb.observability.tracing import create_ydb_span
+
+    exporter = otel_setup
+
+    with create_ydb_span(
+        "ydb.ExecuteQuery",
+        FakeDriverConfig(),
+        node_id=123,
+        peer=("node.example.net", 2136, "dc-a"),
+    ).attach_context():
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_attrs = dict(spans[0].attributes)
+    assert span_attrs["network.peer.address"] == "node.example.net"
+    assert span_attrs["network.peer.port"] == 2136
+    assert span_attrs["ydb.node.dc"] == "dc-a"
+    assert span_attrs["ydb.node.id"] == 123
+
+    metric_attrs = _single_point(metrics_setup, CLIENT_OPERATION_DURATION).attributes
+    assert metric_attrs["database"] == "/test_database"
+    assert metric_attrs["endpoint"] == "test_endpoint:1337"
+    assert metric_attrs["operation.name"] == "ExecuteQuery"
+    assert "network.peer.address" not in metric_attrs
+    assert "network.peer.port" not in metric_attrs
+    assert "ydb.node.dc" not in metric_attrs
+    assert "ydb.node.id" not in metric_attrs
+
+
+def test_create_ydb_span_records_metrics_when_tracing_is_disabled(metrics_setup):
+    from tests.observability.conftest import FakeDriverConfig
+    from ydb.observability import disable_tracing
+    from ydb.observability.metrics import CLIENT_OPERATION_DURATION
+    from ydb.observability.tracing import create_ydb_span
+
+    disable_tracing()
+
+    with create_ydb_span("ydb.ExecuteQuery", FakeDriverConfig()).attach_context():
+        pass
+
+    metric_attrs = _single_point(metrics_setup, CLIENT_OPERATION_DURATION).attributes
+    assert metric_attrs["database"] == "/test_database"
+    assert metric_attrs["endpoint"] == "test_endpoint:1337"
+    assert metric_attrs["operation.name"] == "ExecuteQuery"
+
+
+def test_query_session_count_accumulates_by_attributes(metrics_setup):
+    from ydb.observability.metrics import QUERY_SESSION_COUNT, record_query_session_count
+
+    record_query_session_count(1, "main", "used")
+    record_query_session_count(2, "main", "used")
+    record_query_session_count(1, None, "idle")
+
+    metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_COUNT]
+    values = {tuple(sorted(point.attributes.items())): point.value for point in metric.data.data_points}
+
+    assert (
+        values[
+            (
+                ("ydb.query.session.pool.name", "main"),
+                ("ydb.query.session.state", "used"),
+            )
+        ]
+        == 3
+    )
+    assert (
+        values[
+            (
+                ("ydb.query.session.pool.name", "unknown"),
+                ("ydb.query.session.state", "idle"),
+            )
+        ]
+        == 1
+    )
+
+
+def test_query_session_helpers_record_pool_attributes(metrics_setup):
+    from ydb.observability.metrics import (
+        QUERY_SESSION_CREATE_TIME,
+        QUERY_SESSION_MAX,
+        QUERY_SESSION_MIN,
+        QUERY_SESSION_PENDING_REQUESTS,
+        QUERY_SESSION_TIMEOUTS,
+        record_query_session_create_time,
+        record_query_session_max,
+        record_query_session_pending_requests,
+        record_query_session_timeout,
+    )
+
+    record_query_session_create_time(0.5, "main")
+    record_query_session_max(100, "main")
+    record_query_session_pending_requests(1, None)
+    record_query_session_timeout("main")
+
+    metrics = _metrics_by_name(metrics_setup)
+    create_time = _single_point_from_metrics(metrics, QUERY_SESSION_CREATE_TIME)
+    pending_requests = _single_point_from_metrics(metrics, QUERY_SESSION_PENDING_REQUESTS)
+    timeouts = _single_point_from_metrics(metrics, QUERY_SESSION_TIMEOUTS)
+    session_max = _single_point_from_metrics(metrics, QUERY_SESSION_MAX)
+    session_min = _single_point_from_metrics(metrics, QUERY_SESSION_MIN)
+
+    assert create_time.sum == 0.5
+    assert create_time.attributes == {"ydb.query.session.pool.name": "main"}
+    assert pending_requests.value == 1
+    assert pending_requests.attributes == {"ydb.query.session.pool.name": "unknown"}
+    assert timeouts.value == 1
+    assert timeouts.attributes == {"ydb.query.session.pool.name": "main"}
+    assert session_max.value == 100
+    assert session_max.attributes == {"ydb.query.session.pool.name": "main"}
+    assert session_min.value == 0
+    assert session_min.attributes == {"ydb.query.session.pool.name": "main"}
+
+
+def test_sync_query_session_pool_records_max(metrics_setup):
+    from ydb.observability.metrics import QUERY_SESSION_MAX, QUERY_SESSION_MIN
+    from ydb.query.pool import QuerySessionPool
+
+    QuerySessionPool(driver=object(), size=42, name="sync-pool")
+
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).value == 42
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).attributes == {"ydb.query.session.pool.name": "sync-pool"}
+    assert _single_point(metrics_setup, QUERY_SESSION_MIN).value == 0
+    assert _single_point(metrics_setup, QUERY_SESSION_MIN).attributes == {"ydb.query.session.pool.name": "sync-pool"}
+
+
+def test_sync_query_session_pool_stop_removes_observable_metrics(metrics_setup):
+    from ydb.observability.metrics import QUERY_SESSION_COUNT, QUERY_SESSION_MAX, QUERY_SESSION_MIN
+    from ydb.query.pool import QuerySessionPool
+
+    pool = QuerySessionPool(driver=object(), size=42, name="sync-pool")
+    pool.stop()
+
+    assert _points(metrics_setup, QUERY_SESSION_COUNT) == []
+    assert _points(metrics_setup, QUERY_SESSION_MAX) == []
+    assert _points(metrics_setup, QUERY_SESSION_MIN) == []
+
+
+def test_query_session_pool_name_prefers_explicit_name():
+    from ydb.observability.metrics import query_session_pool_name
+
+    assert query_session_pool_name("my-pool", endpoint="grpc://localhost:2136", database="/local") == "my-pool"
+
+
+def test_query_session_pool_name_uses_connection_string():
+    from ydb.observability.metrics import query_session_pool_name
+
+    assert (
+        query_session_pool_name(None, endpoint="grpc://localhost:2136", database="/local")
+        == "grpc://localhost:2136/local"
+    )
+
+
+def test_query_session_pool_name_normalizes_database_without_leading_slash():
+    from ydb.observability.metrics import query_session_pool_name
+
+    assert (
+        query_session_pool_name(None, endpoint="grpc://localhost:2136", database="local")
+        == "grpc://localhost:2136/local"
+    )
+
+
+def test_query_session_pool_name_falls_back_to_counter_when_nothing_known():
+    from ydb.observability.metrics import query_session_pool_name
+
+    assert query_session_pool_name(None, endpoint=None, database=None).startswith("query-session-pool-")
+
+
+def test_sync_query_session_pool_uses_connection_string_as_default_pool_name(metrics_setup):
+    from tests.observability.conftest import FakeDriverConfig
+    from ydb.observability.metrics import QUERY_SESSION_MAX
+    from ydb.query.pool import QuerySessionPool
+
+    class FakeDriver:
+        _driver_config = FakeDriverConfig(endpoint="grpc://localhost:2136", database="/local")
+
+    QuerySessionPool(driver=FakeDriver(), size=42)
+
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).value == 42
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).attributes == {
+        "ydb.query.session.pool.name": "grpc://localhost:2136/local"
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_query_session_pool_records_max(metrics_setup):
+    from ydb.aio.query.pool import QuerySessionPool
+    from ydb.observability.metrics import QUERY_SESSION_MAX, QUERY_SESSION_MIN
+
+    QuerySessionPool(driver=object(), size=24, name="async-pool")
+
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).value == 24
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).attributes == {"ydb.query.session.pool.name": "async-pool"}
+    assert _single_point(metrics_setup, QUERY_SESSION_MIN).value == 0
+    assert _single_point(metrics_setup, QUERY_SESSION_MIN).attributes == {"ydb.query.session.pool.name": "async-pool"}
+
+
+@pytest.mark.asyncio
+async def test_async_query_session_pool_stop_removes_observable_metrics(metrics_setup):
+    from ydb.aio.query.pool import QuerySessionPool
+    from ydb.observability.metrics import QUERY_SESSION_COUNT, QUERY_SESSION_MAX, QUERY_SESSION_MIN
+
+    pool = QuerySessionPool(driver=object(), size=24, name="async-pool")
+    await pool.stop()
+
+    assert _points(metrics_setup, QUERY_SESSION_COUNT) == []
+    assert _points(metrics_setup, QUERY_SESSION_MAX) == []
+    assert _points(metrics_setup, QUERY_SESSION_MIN) == []
+
+
+@pytest.mark.asyncio
+async def test_async_query_session_pool_uses_connection_string_as_default_pool_name(metrics_setup):
+    from tests.observability.conftest import FakeDriverConfig
+    from ydb.aio.query.pool import QuerySessionPool
+    from ydb.observability.metrics import QUERY_SESSION_MAX
+
+    class FakeDriver:
+        _driver_config = FakeDriverConfig(endpoint="grpc://localhost:2136", database="/local")
+
+    QuerySessionPool(driver=FakeDriver(), size=24)
+
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).value == 24
+    assert _single_point(metrics_setup, QUERY_SESSION_MAX).attributes == {
+        "ydb.query.session.pool.name": "grpc://localhost:2136/local"
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_query_session_pool_auto_names_do_not_collide(metrics_setup):
+    from ydb.aio.query.pool import QuerySessionPool as AsyncQuerySessionPool
+    from ydb.observability.metrics import QUERY_SESSION_MAX
+    from ydb.query.pool import QuerySessionPool
+
+    QuerySessionPool(driver=object(), size=42)
+    AsyncQuerySessionPool(driver=object(), size=24)
+
+    metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_MAX]
+    values = {point.attributes["ydb.query.session.pool.name"]: point.value for point in metric.data.data_points}
+
+    assert len(values) == 2
+    assert sorted(values.values()) == [24, 42]
+
+
+def test_retry_operation_sync_records_retry_metrics(metrics_setup):
+    from ydb import issues
+    from ydb.observability.metrics import RETRY_ATTEMPTS, RETRY_DURATION
+    from ydb.retries import RetrySettings, retry_operation_sync
+
+    attempts = {"count": 0}
+
+    def flaky():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise issues.Aborted("retry")
+        return "ok"
+
+    assert retry_operation_sync(flaky, RetrySettings(max_retries=5)) == "ok"
+
+    metrics = _metrics_by_name(metrics_setup)
+    duration = _single_point_from_metrics(metrics, RETRY_DURATION)
+    retry_attempts = _single_point_from_metrics(metrics, RETRY_ATTEMPTS)
+
+    assert duration.count == 1
+    assert duration.sum >= 0
+    assert duration.attributes == {}
+    assert retry_attempts.sum == 3
+
+
+async def _async_value():
+    return "ok"
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_async_records_retry_metrics(metrics_setup):
+    from ydb.observability.metrics import RETRY_ATTEMPTS, RETRY_DURATION
+    from ydb.retries import retry_operation_async
+
+    assert await retry_operation_async(_async_value) == "ok"
+
+    metrics = _metrics_by_name(metrics_setup)
+    duration = _single_point_from_metrics(metrics, RETRY_DURATION)
+    retry_attempts = _single_point_from_metrics(metrics, RETRY_ATTEMPTS)
+
+    assert duration.count == 1
+    assert duration.sum >= 0
+    assert duration.attributes == {}
+    assert retry_attempts.sum == 1
+
+
+class TestOpenTelemetryPublicApi:
+    def test_enable_disable_metrics_roundtrip(self):
+        from ydb.opentelemetry import disable_metrics, enable_metrics
+        from ydb.observability.metrics import is_metrics_enabled
+
+        reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[reader])
+
+        disable_metrics()
+        assert not is_metrics_enabled()
+        enable_metrics(provider)
+        assert is_metrics_enabled()
+        disable_metrics()
+        assert not is_metrics_enabled()
+        provider.shutdown()
+
+    def test_enable_metrics_is_idempotent(self):
+        from ydb.opentelemetry.metrics_plugin import _enable_metrics
+        from ydb.observability.metrics import is_metrics_enabled
+        from ydb.opentelemetry import disable_metrics
+
+        disable_metrics()
+        reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[reader])
+        _enable_metrics(provider)
+        _enable_metrics(MeterProvider(metric_readers=[InMemoryMetricReader()]))
+        assert is_metrics_enabled()
+        disable_metrics()
+        provider.shutdown()
+
+    def test_enable_metrics_with_none_uses_default_meter(self):
+        from ydb.opentelemetry import disable_metrics
+        from ydb.observability.metrics import is_metrics_enabled
+        from ydb.opentelemetry.metrics_plugin import _disable_metrics, _enable_metrics
+
+        disable_metrics()
+        _enable_metrics(None)
+        assert is_metrics_enabled()
+        _disable_metrics()
+        assert not is_metrics_enabled()
+
+    def test_enable_metrics_rejects_invalid_provider(self):
+        from ydb.opentelemetry.metrics_plugin import _enable_metrics
+        from ydb.opentelemetry import disable_metrics
+
+        disable_metrics()
+        with pytest.raises(TypeError, match="MeterProvider"):
+            _enable_metrics(object())
+
+    def test_enable_metrics_import_error(self, monkeypatch):
+        import ydb.opentelemetry as otel
+
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "ydb.opentelemetry.metrics_plugin":
+                raise ImportError("missing otel")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        with pytest.raises(ImportError, match="opentelemetry"):
+            otel.enable_metrics()
+
+    def test_disable_metrics_without_opentelemetry_is_noop(self, monkeypatch):
+        import ydb.opentelemetry as otel
+
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "ydb.opentelemetry.metrics_plugin":
+                raise ImportError("missing otel")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        otel.disable_metrics()
+
+
+class TestEndpointHelpers:
+    @pytest.mark.parametrize(
+        "endpoint,expected",
+        [
+            ("grpc://localhost:2136", ("localhost", 2136)),
+            ("grpcs://localhost:2136", ("localhost", 2136)),
+            ("localhost:2135", ("localhost", 2135)),
+            ("localhost", ("localhost", 0)),
+            ("[::1]:2136", ("[::1]", 2136)),
+            ("grpc://[2001:db8::1]:2136", ("[2001:db8::1]", 2136)),
+            ("host:badport", ("host", 0)),
+            (None, ("", 0)),
+        ],
+    )
+    def test_split_endpoint(self, endpoint, expected):
+        from ydb.observability._endpoint import split_endpoint
+
+        assert split_endpoint(endpoint) == expected
+
+    def test_build_ydb_metrics_attrs(self):
+        from tests.observability.conftest import FakeDriverConfig
+        from ydb.observability.metrics import _build_ydb_metrics_attrs
+
+        attrs = _build_ydb_metrics_attrs(FakeDriverConfig(endpoint="grpc://node:2136", database="/db"))
+        assert attrs == {"database": "/db", "endpoint": "node:2136"}
+
+
+class TestTracingTelemetryFacade:
+    def test_telemetry_operation_forwards_to_span_and_metrics(self, metrics_setup, otel_setup):
+        from tests.observability.conftest import FakeDriverConfig
+        from ydb.observability.tracing import create_ydb_span
+
+        telemetry = create_ydb_span("ydb.ExecuteQuery", FakeDriverConfig())
+        telemetry.set_attribute("database", "/db")
+        telemetry.set_error(ValueError("fail"))
+        telemetry.end()
+
+        spans = otel_setup.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code.name == "ERROR"
+
+    def test_telemetry_context_end_on_exit_false(self, metrics_setup, otel_setup):
+        from tests.observability.conftest import FakeDriverConfig
+        from ydb.observability.metrics import CLIENT_OPERATION_DURATION
+        from ydb.observability.tracing import create_ydb_span
+
+        telemetry = create_ydb_span("ydb.ExecuteQuery", FakeDriverConfig())
+        with telemetry.attach_context(end_on_exit=False):
+            pass
+
+        assert CLIENT_OPERATION_DURATION not in _metrics_by_name(metrics_setup)
+        assert len(otel_setup.get_finished_spans()) == 0
+
+        telemetry.end()
+        assert len(otel_setup.get_finished_spans()) == 1
+        assert CLIENT_OPERATION_DURATION in _metrics_by_name(metrics_setup)
+
+    def test_set_peer_attributes_skips_none(self):
+        from ydb.observability.tracing import set_peer_attributes
+
+        span = MagicMock()
+        set_peer_attributes(span, None)
+        span.set_attribute.assert_not_called()
+
+    def test_set_peer_attributes_sets_network_fields(self):
+        from ydb.observability.tracing import set_peer_attributes
+
+        span = MagicMock()
+        set_peer_attributes(span, ("node.example.net", 2136, "dc-a"))
+
+        span.set_attribute.assert_any_call("network.peer.address", "node.example.net")
+        span.set_attribute.assert_any_call("network.peer.port", 2136)
+        span.set_attribute.assert_any_call("ydb.node.dc", "dc-a")
+
+    def test_span_finish_callback_records_error(self):
+        from ydb.observability.tracing import span_finish_callback
+
+        span = MagicMock()
+        finish = span_finish_callback(span)
+        finish(RuntimeError("boom"))
+
+        span.set_error.assert_called_once()
+        span.end.assert_called_once()
+
+    def test_tracing_plugin_sets_transport_error(self, otel_setup):
+        from opentelemetry import trace
+        from ydb import issues
+        from ydb.opentelemetry.plugin import _set_error_on_span
+
+        error = issues.Error("lost")
+        error.status = issues.StatusCode.CONNECTION_LOST
+
+        raw_span = trace.get_tracer("test").start_span("x")
+        _set_error_on_span(raw_span, error)
+        raw_span.end()
+
+        finished = otel_setup.get_finished_spans()[0]
+        assert finished.attributes["error.type"] == "transport_error"
+
+    def test_tracing_plugin_sets_generic_error_type(self, otel_setup):
+        from opentelemetry import trace
+        from ydb.opentelemetry.plugin import _set_error_on_span
+
+        raw_span = trace.get_tracer("test").start_span("x")
+        _set_error_on_span(raw_span, ValueError("bad"))
+        raw_span.end()
+
+        finished = otel_setup.get_finished_spans()[0]
+        assert finished.attributes["error.type"] == "ValueError"
+
+    def test_tracing_plugin_attach_context_without_end_on_exit(self, otel_setup):
+        from opentelemetry import trace
+        from ydb.opentelemetry.plugin import TracingSpan
+
+        raw_span = trace.get_tracer("test").start_span("x")
+        wrapper = TracingSpan(raw_span)
+        with wrapper.attach_context(end_on_exit=False):
+            pass
+
+        assert len(otel_setup.get_finished_spans()) == 0
+        wrapper.end()
+        assert len(otel_setup.get_finished_spans()) == 1
+
+
+class TestQuerySessionPoolMetricsInstrumentation:
+    def test_query_session_init_metrics_defaults(self):
+        from ydb.query.session import QuerySession
+
+        session = QuerySession(MagicMock())
+        assert session._session_metrics.pool_name is None
+        assert session._session_metrics.state == "used"
+        assert session._session_metrics._counted is False
+
+    def test_sync_pool_acquire_from_queue_updates_session_count(self, metrics_setup):
+        from ydb.observability.metrics import QUERY_SESSION_COUNT, SessionMetrics
+        from ydb.query.pool import QuerySessionPool
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="sync-pool")
+        session = MagicMock()
+        session.is_active = True
+        session.session_id = "session-1"
+        session._session_metrics = SessionMetrics()
+        session._session_metrics.state = "idle"
+        pool._queue.put_nowait(session)
+
+        acquired = pool.acquire()
+        assert acquired is session
+
+        metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_COUNT]
+        values = {tuple(sorted(point.attributes.items())): point.value for point in metric.data.data_points}
+        assert values[(("ydb.query.session.pool.name", "sync-pool"), ("ydb.query.session.state", "used"))] == 1
+        assert values[(("ydb.query.session.pool.name", "sync-pool"), ("ydb.query.session.state", "idle"))] == -1
+
+    def test_sync_pool_release_updates_session_count(self, metrics_setup):
+        from ydb.observability.metrics import QUERY_SESSION_COUNT, SessionMetrics
+        from ydb.query.pool import QuerySessionPool
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="sync-pool")
+        session = MagicMock()
+        session.session_id = "session-1"
+        session._session_metrics = SessionMetrics()
+        pool.release(session)
+
+        metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_COUNT]
+        values = {tuple(sorted(point.attributes.items())): point.value for point in metric.data.data_points}
+        assert values[(("ydb.query.session.pool.name", "sync-pool"), ("ydb.query.session.state", "idle"))] == 1
+        assert values[(("ydb.query.session.pool.name", "sync-pool"), ("ydb.query.session.state", "used"))] == -1
+
+    def test_sync_pool_acquire_timeout_records_pending_and_timeout(self, metrics_setup):
+        from ydb import issues
+        from ydb.observability.metrics import QUERY_SESSION_PENDING_REQUESTS, QUERY_SESSION_TIMEOUTS
+        from ydb.query.pool import QuerySessionPool
+
+        pool = QuerySessionPool(driver=MagicMock(), size=1, name="sync-pool")
+        pool._current_size = 1
+
+        with pytest.raises(issues.SessionPoolEmpty):
+            pool.acquire(timeout=0.01)
+
+        assert _single_point(metrics_setup, QUERY_SESSION_TIMEOUTS).value == 1
+        assert _sum_value(metrics_setup, QUERY_SESSION_PENDING_REQUESTS) == 0
+
+    def test_sync_pool_create_new_session_records_create_time(self, metrics_setup, monkeypatch):
+        from ydb.observability.metrics import QUERY_SESSION_CREATE_TIME
+        from ydb.query.pool import QuerySessionPool
+
+        mock_session = MagicMock()
+        mock_session.is_active = True
+        mock_session.session_id = "new-session"
+        mock_session.create = MagicMock()
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="sync-pool")
+        monkeypatch.setattr("ydb.query.pool.QuerySession", lambda *args, **kwargs: mock_session)
+
+        acquired = pool.acquire()
+        assert acquired is mock_session
+        assert _histogram_sum(metrics_setup, QUERY_SESSION_CREATE_TIME) >= 0
+
+    def test_sync_session_create_increments_session_count(self, metrics_setup, monkeypatch):
+        from tests.observability.conftest import FakeDriverConfig
+        from ydb.observability.metrics import QUERY_SESSION_COUNT, SessionMetrics
+        from ydb.query.session import QuerySession
+
+        qs = QuerySession.__new__(QuerySession)
+        qs._driver = MagicMock()
+        qs._driver._driver_config = FakeDriverConfig()
+        qs._session_id = None
+        qs._closed = False
+        qs._invalidated = False
+        qs._session_metrics = SessionMetrics()
+        qs._session_metrics.pool_name = "session-pool"
+        qs._stream = None
+
+        @contextmanager
+        def fake_span_ctx(**kwargs):
+            yield MagicMock()
+
+        monkeypatch.setattr(
+            "ydb.query.session.create_ydb_span", lambda *args, **kwargs: MagicMock(attach_context=fake_span_ctx)
+        )
+        monkeypatch.setattr(qs, "_create_call", MagicMock())
+        monkeypatch.setattr(qs, "_attach", MagicMock())
+
+        qs.create()
+        assert qs._session_metrics._counted
+        assert _single_point(metrics_setup, QUERY_SESSION_COUNT).attributes["ydb.query.session.state"] == "used"
+
+    def test_sync_session_close_decrements_session_count(self, metrics_setup):
+        from ydb.observability.metrics import QUERY_SESSION_COUNT, SessionMetrics
+        from ydb.query.session import QuerySession
+
+        qs = QuerySession.__new__(QuerySession)
+        qs._closed = False
+        qs._invalidated = False
+        qs._session_metrics = SessionMetrics()
+        qs._session_metrics.pool_name = "session-pool"
+        qs._session_metrics._counted = True
+        qs._stream = None
+
+        qs._close_session()
+        assert not qs._session_metrics._counted
+        assert _sum_value(metrics_setup, QUERY_SESSION_COUNT) == -1
+
+    @pytest.mark.asyncio
+    async def test_async_pool_acquire_from_queue_updates_session_count(self, metrics_setup):
+        from ydb.aio.query.pool import QuerySessionPool
+        from ydb.observability.metrics import QUERY_SESSION_COUNT
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="async-pool")
+        session = MagicMock()
+        session.is_active = True
+        session.session_id = "session-1"
+        pool._queue.put_nowait(session)
+
+        acquired = await pool.acquire()
+        assert acquired is session
+
+        metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_COUNT]
+        values = {tuple(sorted(point.attributes.items())): point.value for point in metric.data.data_points}
+        assert values[(("ydb.query.session.pool.name", "async-pool"), ("ydb.query.session.state", "used"))] == 1
+
+    @pytest.mark.asyncio
+    async def test_async_pool_release_updates_session_count(self, metrics_setup):
+        from ydb.aio.query.pool import QuerySessionPool
+        from ydb.observability.metrics import QUERY_SESSION_COUNT
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="async-pool")
+        session = MagicMock()
+        session.session_id = "session-1"
+        await pool.release(session)
+
+        metric = _metrics_by_name(metrics_setup)[QUERY_SESSION_COUNT]
+        values = {tuple(sorted(point.attributes.items())): point.value for point in metric.data.data_points}
+        assert values[(("ydb.query.session.pool.name", "async-pool"), ("ydb.query.session.state", "idle"))] == 1
+
+    @pytest.mark.asyncio
+    async def test_async_pool_acquire_timeout_records_timeout(self, metrics_setup):
+        from ydb import issues
+        from ydb.aio.query.pool import QuerySessionPool
+        from ydb.observability.metrics import QUERY_SESSION_TIMEOUTS
+
+        pool = QuerySessionPool(driver=MagicMock(), size=1, name="async-pool")
+        pool._current_size = 1
+
+        with pytest.raises(issues.SessionPoolEmpty):
+            await pool.acquire(timeout=0.01)
+
+        assert _single_point(metrics_setup, QUERY_SESSION_TIMEOUTS).value == 1
+
+    @pytest.mark.asyncio
+    async def test_async_pool_create_new_session_records_create_time(self, metrics_setup, monkeypatch):
+        from ydb.aio.query.pool import QuerySessionPool
+        from ydb.observability.metrics import QUERY_SESSION_CREATE_TIME
+
+        mock_session = MagicMock()
+        mock_session.is_active = True
+        mock_session.session_id = "new-session"
+        mock_session.create = AsyncMock()
+
+        pool = QuerySessionPool(driver=MagicMock(), size=2, name="async-pool")
+        monkeypatch.setattr("ydb.aio.query.pool.QuerySession", lambda *args, **kwargs: mock_session)
+
+        acquired = await pool.acquire()
+        assert acquired is mock_session
+        assert _histogram_sum(metrics_setup, QUERY_SESSION_CREATE_TIME) >= 0
+
+    @pytest.mark.asyncio
+    async def test_async_session_create_increments_session_count(self, metrics_setup, monkeypatch):
+        from tests.observability.conftest import FakeDriverConfig
+        from ydb.aio.query.session import QuerySession
+        from ydb.observability.metrics import QUERY_SESSION_COUNT, SessionMetrics
+
+        qs = QuerySession.__new__(QuerySession)
+        qs._driver = MagicMock()
+        qs._driver._driver_config = FakeDriverConfig()
+        qs._session_id = None
+        qs._closed = False
+        qs._invalidated = False
+        qs._session_metrics = SessionMetrics()
+        qs._session_metrics.pool_name = "async-session-pool"
+        qs._stream = None
+        qs._status_stream = None
+        qs._loop = __import__("asyncio").get_running_loop()
+
+        @contextmanager
+        def fake_span_ctx(**kwargs):
+            yield MagicMock()
+
+        monkeypatch.setattr(
+            "ydb.aio.query.session.create_ydb_span", lambda *args, **kwargs: MagicMock(attach_context=fake_span_ctx)
+        )
+        monkeypatch.setattr(qs, "_create_call", AsyncMock())
+        monkeypatch.setattr(qs, "_attach", AsyncMock())
+
+        await qs.create()
+        assert qs._session_metrics._counted
+        assert _single_point(metrics_setup, QUERY_SESSION_COUNT).value == 1

--- a/tests/observability/test_observability_enable.py
+++ b/tests/observability/test_observability_enable.py
@@ -205,9 +205,12 @@ class TestNoopProviderExplicit:
         """A user explicitly picking NoopTracingProvider is a valid choice."""
         enable_tracing(NoopTracingProvider())
         assert _registry.is_active() is True
-        # But the produced span is still a NoopSpan — no attributes recorded.
+        # The produced telemetry object is still a no-op: it wraps a NoopSpan and
+        # can be used unconditionally without recording anything.
         span = create_ydb_span(SpanName.CREATE_SESSION, FakeDriverConfig())
-        assert isinstance(span, NoopSpan)
+        with span.attach_context() as active:
+            active.set_attribute("db.system.name", "ydb")
+            active.set_error(RuntimeError("ignored"))
 
 
 class TestOtelEnableAlsoResets:

--- a/tests/observability/test_tracing_async.py
+++ b/tests/observability/test_tracing_async.py
@@ -508,15 +508,19 @@ class TestAsyncConcurrentSpansIsolation:
             return qs
 
         async def do_execute(qs):
-            fake_stream = _slow_async_iter()
-            with patch.object(QuerySession, "_execute_call", new_callable=AsyncMock, return_value=fake_stream):
-                result = await qs.execute("SELECT 1")
-                async for _ in result:
-                    pass
+            result = await qs.execute("SELECT 1")
+            async for _ in result:
+                pass
 
         qs1 = _make_session()
         qs2 = _make_session()
-        await asyncio.gather(do_execute(qs1), do_execute(qs2))
+        # Patch the class method once around the whole gather. Patching it concurrently
+        # inside each task (on the same class attribute) corrupts save/restore and leaks
+        # the mock onto QuerySession, breaking later real async query tests.
+        with patch.object(
+            QuerySession, "_execute_call", new_callable=AsyncMock, side_effect=lambda *a, **k: _slow_async_iter()
+        ):
+            await asyncio.gather(do_execute(qs1), do_execute(qs2))
 
         spans = _get_spans(exporter, SpanName.EXECUTE_QUERY)
         assert len(spans) == 2

--- a/tests/observability/test_tracing_sync.py
+++ b/tests/observability/test_tracing_sync.py
@@ -314,7 +314,7 @@ class TestNoSpansWhenDisabled:
     def test_no_spans_without_enable_tracing(self):
         """Without enable_tracing(), the registry uses noop — no spans are created."""
 
-        from tests.tracing.conftest import _exporter
+        from tests.observability.conftest import _exporter
 
         _registry.set_provider(None)
         _exporter.clear()

--- a/ydb/aio/query/pool.py
+++ b/ydb/aio/query/pool.py
@@ -22,6 +22,7 @@ from ...query.base import BaseQueryTxMode, QueryExplainResultFormat
 from ...query.base import QueryClientSettings
 from ... import convert
 from ... import issues
+from ...observability.metrics import QuerySessionPoolMetrics
 from ..._grpc.grpcwrapper import common_utils
 from ..._grpc.grpcwrapper import ydb_query_public_types as _ydb_query_public
 
@@ -38,11 +39,13 @@ class QuerySessionPool:
         *,
         query_client_settings: Optional[QueryClientSettings] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
+        name: Optional[str] = None,
     ):
         """
         :param driver: A driver instance
         :param size: Size of session pool
         :param query_client_settings: ydb.QueryClientSettings object to configure QueryService behavior
+        :param name: Optional session pool name for observability metrics.
         """
 
         self._driver = driver
@@ -52,10 +55,13 @@ class QuerySessionPool:
         self._current_size = 0
         self._loop = asyncio.get_running_loop() if loop is None else loop
         self._query_client_settings = query_client_settings
+        self._metrics = QuerySessionPoolMetrics(name, driver, self._size)
 
     async def _create_new_session(self):
         session = QuerySession(self._driver, settings=self._query_client_settings)
-        await session.create()
+        self._metrics.attach(session)
+        with self._metrics.measure_create():
+            await session.create()
         logger.debug(f"New session was created for pool. Session id: {session.session_id}")
         return session
 
@@ -81,41 +87,44 @@ class QuerySessionPool:
             pass
 
         if session is None and self._current_size == self._size:
-            queue_get = asyncio.ensure_future(self._queue.get())
-            task_stop = asyncio.ensure_future(self._should_stop.wait())
-            task_timeout = (
-                asyncio.ensure_future(asyncio.sleep(effective_timeout)) if effective_timeout is not None else None
-            )
-            wait_tasks = [t for t in (queue_get, task_stop, task_timeout) if t is not None]
-            try:
-                done, _ = await asyncio.wait(wait_tasks, return_when=asyncio.FIRST_COMPLETED)
-            except asyncio.CancelledError:
+            with self._metrics.track_pending():
+                queue_get = asyncio.ensure_future(self._queue.get())
+                task_stop = asyncio.ensure_future(self._should_stop.wait())
+                task_timeout = (
+                    asyncio.ensure_future(asyncio.sleep(effective_timeout)) if effective_timeout is not None else None
+                )
+                wait_tasks = [t for t in (queue_get, task_stop, task_timeout) if t is not None]
+                try:
+                    done, _ = await asyncio.wait(wait_tasks, return_when=asyncio.FIRST_COMPLETED)
+                except asyncio.CancelledError:
+                    task_stop.cancel()
+                    if task_timeout is not None:
+                        task_timeout.cancel()
+                    cancelled = queue_get.cancel()
+                    if not cancelled and not queue_get.exception():
+                        await self.release(queue_get.result())
+                    raise
+
                 task_stop.cancel()
                 if task_timeout is not None:
                     task_timeout.cancel()
-                cancelled = queue_get.cancel()
-                if not cancelled and not queue_get.exception():
-                    await self.release(queue_get.result())
-                raise
 
-            task_stop.cancel()
-            if task_timeout is not None:
-                task_timeout.cancel()
+                if task_stop in done:
+                    queue_get.cancel()
+                    raise RuntimeError("An attempt to take session from closed session pool.")
 
-            if task_stop in done:
-                queue_get.cancel()
-                raise RuntimeError("An attempt to take session from closed session pool.")
+                if task_timeout is not None and task_timeout in done:
+                    cancelled = queue_get.cancel()
+                    if not cancelled and not queue_get.exception():
+                        await self.release(queue_get.result())
+                    self._metrics.on_timeout()
+                    raise issues.SessionPoolEmpty("Timeout on acquire session")
 
-            if task_timeout is not None and task_timeout in done:
-                cancelled = queue_get.cancel()
-                if not cancelled and not queue_get.exception():
-                    await self.release(queue_get.result())
-                raise issues.SessionPoolEmpty("Timeout on acquire session")
-
-            session = queue_get.result()
+                session = queue_get.result()
 
         if session is not None:
             if session.is_active:
+                self._metrics.on_acquired(session)
                 logger.debug(f"Acquired active session from queue: {session.session_id}")
                 return session
             else:
@@ -137,6 +146,7 @@ class QuerySessionPool:
 
     async def release(self, session: QuerySession) -> None:
         """Release a session back to Session Pool."""
+        self._metrics.on_released(session)
         self._queue.put_nowait(session)
         logger.debug("Session returned to queue: %s", session.session_id)
 
@@ -268,6 +278,7 @@ class QuerySessionPool:
         await asyncio.gather(*tasks)
 
         logger.debug("All session were deleted.")
+        self._metrics.close()
 
     async def __aenter__(self):
         return self

--- a/ydb/aio/query/pool_test.py
+++ b/ydb/aio/query/pool_test.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 from ydb import issues
 from ydb.aio.query.pool import QuerySessionPool
 from ydb.aio.query.session import QuerySession
+from ydb.observability.metrics import QuerySessionPoolMetrics
 
 
 def _make_pool(size=1):
@@ -19,6 +20,7 @@ def _make_pool(size=1):
     pool._current_size = 0
     pool._loop = asyncio.get_event_loop()
     pool._query_client_settings = None
+    pool._metrics = QuerySessionPoolMetrics("test-query-session-pool", driver, size)
     return pool
 
 

--- a/ydb/aio/query/session.py
+++ b/ydb/aio/query/session.py
@@ -109,6 +109,7 @@ class QuerySession(BaseQuerySession["AsyncDriver"]):
             await self._create_call(settings=settings)
             set_peer_attributes(span, self._peer)
             await self._attach()
+            self._session_metrics.count_open()
 
         return self
 

--- a/ydb/observability/__init__.py
+++ b/ydb/observability/__init__.py
@@ -1,16 +1,17 @@
 """Vendor-neutral observability entrypoints for the YDB SDK.
 
-Users pick a tracing backend and register it here:
+Users pick tracing and/or metrics backends and register them here:
 
 .. code-block:: python
 
-    from ydb.observability import enable_tracing
+    from ydb.observability import enable_tracing, enable_metrics
     from ydb.opentelemetry import OtelTracingProvider
 
     enable_tracing(OtelTracingProvider())  # or any custom TracingProvider
 
-The SDK itself never imports ``opentelemetry`` — until a provider is enabled,
-every span is a :class:`~ydb.observability.tracing.NoopSpan`.
+The SDK itself never imports ``opentelemetry`` — until a backend is enabled,
+every span is a :class:`~ydb.observability.tracing.NoopSpan` and every metric is
+dropped by a no-op registry.
 """
 
 from typing import List, Optional
@@ -23,6 +24,12 @@ from ydb.observability.tracing import (
     TracingProvider,
     _registry,
     _tracing_build_info_tokens,
+)
+from ydb.observability.metrics import (
+    MetricsProvider,
+    _metrics_build_info_tokens,
+    _reset_metrics_provider,
+    _set_metrics_provider,
 )
 
 
@@ -49,26 +56,43 @@ def get_active_provider() -> Optional[TracingProvider]:
     return _registry.get_provider() if _registry.is_active() else None
 
 
+def enable_metrics(provider: MetricsProvider) -> None:
+    """Install *provider* as the active metrics backend.
+
+    Calling this a second time replaces the previous backend. To turn metrics off
+    again call :func:`disable_metrics`.
+    """
+    _set_metrics_provider(provider)
+
+
+def disable_metrics() -> None:
+    """Reset the metrics backend to the built-in no-op provider."""
+    _reset_metrics_provider()
+
+
 def sdk_build_info_tokens() -> List[str]:
     """All ``x-ydb-sdk-build-info`` feature tokens contributed by observability.
 
     Aggregated across observability features so the SDK build-info header advertises
-    every capability the client has turned on. Tracing contributes
-    ``ydb-sdk-tracing/<v>`` while active; future features (e.g. metrics via
-    ``enable_metrics``) append their own tokens here.
+    every capability the client has turned on: tracing contributes
+    ``ydb-sdk-tracing/<v>`` while active, metrics contribute ``ydb-sdk-metrics/<v>``.
     """
     tokens: List[str] = []
     tokens.extend(_tracing_build_info_tokens())
+    tokens.extend(_metrics_build_info_tokens())
     return tokens
 
 
 __all__ = [
+    "MetricsProvider",
     "NoopSpan",
     "NoopTracingProvider",
     "Span",
     "SpanName",
     "TracingProvider",
+    "disable_metrics",
     "disable_tracing",
+    "enable_metrics",
     "enable_tracing",
     "get_active_provider",
 ]

--- a/ydb/observability/_endpoint.py
+++ b/ydb/observability/_endpoint.py
@@ -1,0 +1,23 @@
+"""Shared endpoint parsing used by both tracing and metrics attributes."""
+
+from typing import Optional, Tuple
+
+
+def split_endpoint(endpoint: Optional[str]) -> Tuple[str, int]:
+    ep = endpoint or ""
+    if ep.startswith("grpcs://"):
+        ep = ep[len("grpcs://") :]
+    elif ep.startswith("grpc://"):
+        ep = ep[len("grpc://") :]
+
+    if ep.startswith("["):
+        close = ep.find("]")
+        if close != -1 and len(ep) > close + 1 and ep[close + 1] == ":":
+            host = ep[: close + 1]
+            port_s = ep[close + 2 :]
+            return host, int(port_s) if port_s.isdigit() else 0
+
+    host, sep, port_s = ep.rpartition(":")
+    if not sep:
+        return ep, 0
+    return host, int(port_s) if port_s.isdigit() else 0

--- a/ydb/observability/metrics.py
+++ b/ydb/observability/metrics.py
@@ -1,0 +1,622 @@
+"""Vendor-neutral client metrics interface, Noop backend and SDK helpers.
+
+The SDK records metrics only after :func:`ydb.observability.enable_metrics` installs a
+concrete :class:`MetricsProvider` (OpenTelemetry in :mod:`ydb.opentelemetry`, or any
+custom one). Until then every helper is a cheap no-op, so metrics stay independent from
+tracing and safe to call from hot paths — and the SDK never depends on ``opentelemetry``
+being importable.
+
+A provider handles three instrument kinds:
+
+* ``record(name, value, attributes)`` — a value distribution (histogram);
+* ``add(name, value, attributes)`` — an additive counter (may go negative, i.e. up/down);
+* ``observe_gauge(name, callback)`` — an asynchronous gauge: the SDK owns the accumulated
+  state (e.g. open sessions per pool) and the provider reads it via ``callback`` at
+  collection time. This keeps the pool bookkeeping vendor-neutral and out of the backend.
+"""
+
+import time
+import threading
+import itertools
+import functools
+import inspect
+from typing import Any, Callable, Dict, Iterable, List, Optional, Protocol, Tuple
+
+from ydb.observability._endpoint import split_endpoint
+
+CLIENT_OPERATION_DURATION = "db.client.operation.duration"
+CLIENT_OPERATION_FAILED = "ydb.client.operation.failed"
+QUERY_SESSION_COUNT = "ydb.query.session.count"
+QUERY_SESSION_CREATE_TIME = "ydb.query.session.create_time"
+QUERY_SESSION_PENDING_REQUESTS = "ydb.query.session.pending_requests"
+QUERY_SESSION_TIMEOUTS = "ydb.query.session.timeouts"
+QUERY_SESSION_MAX = "ydb.query.session.max"
+QUERY_SESSION_MIN = "ydb.query.session.min"
+RETRY_ATTEMPTS = "ydb.client.retry.attempts"
+RETRY_DURATION = "ydb.client.retry.duration"
+
+METRICS_SDK_BUILD_INFO = "ydb-sdk-metrics/0.1.0"
+
+DURATION_BUCKETS_SECONDS = (
+    0.001,
+    0.005,
+    0.01,
+    0.05,
+    0.1,
+    0.5,
+    1,
+    5,
+    10,
+)
+RETRY_DURATION_BUCKETS_SECONDS = (
+    0.001,
+    0.005,
+    0.01,
+    0.05,
+    0.1,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    30,
+)
+ATTEMPT_BUCKETS = (1, 2, 3, 4, 5, 7, 10, 20)
+_UNKNOWN_POOL = "unknown"
+_pool_name_counter = itertools.count(1)
+_pool_name_lock = threading.Lock()
+_OPERATION_ATTR_KEYS = frozenset(
+    {
+        "database",
+        "endpoint",
+        "operation.name",
+    }
+)
+_CLIENT_OPERATION_NAMES = frozenset(
+    {
+        "ExecuteQuery",
+        "Commit",
+        "Rollback",
+        "CreateSession",
+        "BeginTransaction",
+    }
+)
+_CLIENT_OPERATION_NAME_BY_INPUT = {
+    "ydb.ExecuteQuery": "ExecuteQuery",
+    "ExecuteQuery": "ExecuteQuery",
+    "ydb.Commit": "Commit",
+    "Commit": "Commit",
+    "ydb.Rollback": "Rollback",
+    "Rollback": "Rollback",
+    "ydb.CreateSession": "CreateSession",
+    "CreateSession": "CreateSession",
+    "ydb.BeginTransaction": "BeginTransaction",
+    "BeginTransaction": "BeginTransaction",
+}
+
+# A gauge callback returns the current ``(value, attributes)`` observations.
+GaugeCallback = Callable[[], Iterable[Tuple[float, Dict[str, Any]]]]
+
+
+class MetricsProvider(Protocol):
+    """Pluggable metrics backend.
+
+    Implement this to wire the SDK into any metrics system. Three methods cover the
+    three instrument kinds the SDK uses; see the module docstring for the semantics.
+    """
+
+    def record(self, name: str, value: float, attributes: Optional[Dict[str, Any]] = None) -> None: ...
+
+    def add(self, name: str, value: int, attributes: Optional[Dict[str, Any]] = None) -> None: ...
+
+    def observe_gauge(self, name: str, callback: GaugeCallback) -> None:
+        """Register an asynchronous gauge whose current values *callback* returns."""
+        ...
+
+
+class NoopMetricsProvider:
+    """Default backend used while metrics are disabled — drops everything."""
+
+    def record(self, name, value, attributes=None):
+        pass
+
+    def add(self, name, value, attributes=None):
+        pass
+
+    def observe_gauge(self, name, callback):
+        pass
+
+
+_NOOP_PROVIDER = NoopMetricsProvider()
+_provider: MetricsProvider = _NOOP_PROVIDER
+
+# Accumulated state for the asynchronous gauges, owned by the SDK (vendor-neutral) and
+# read by whatever provider is installed via ``observe_gauge``.
+_gauge_lock = threading.Lock()
+_session_count_state: Dict[Tuple, int] = {}
+_session_max_state: Dict[Tuple, int] = {}
+
+
+def is_metrics_enabled() -> bool:
+    return _provider is not _NOOP_PROVIDER
+
+
+def _observe_session_count() -> List[Tuple[float, Dict[str, Any]]]:
+    with _gauge_lock:
+        return [(value, dict(attrs)) for attrs, value in _session_count_state.items()]
+
+
+def _observe_session_max() -> List[Tuple[float, Dict[str, Any]]]:
+    with _gauge_lock:
+        return [(value, dict(attrs)) for attrs, value in _session_max_state.items()]
+
+
+def _observe_session_min() -> List[Tuple[float, Dict[str, Any]]]:
+    # The SDK never configures a pool minimum, so this is always 0 for every known pool.
+    with _gauge_lock:
+        return [(0, dict(attrs)) for attrs in _session_max_state]
+
+
+_OBSERVABLE_GAUGES = (
+    (QUERY_SESSION_COUNT, _observe_session_count),
+    (QUERY_SESSION_MAX, _observe_session_max),
+    (QUERY_SESSION_MIN, _observe_session_min),
+)
+
+
+def _set_metrics_provider(provider: Optional[MetricsProvider]) -> None:
+    global _provider
+
+    _provider = provider if provider is not None else _NOOP_PROVIDER
+    if _provider is not _NOOP_PROVIDER:
+        for name, callback in _OBSERVABLE_GAUGES:
+            _provider.observe_gauge(name, callback)
+
+
+def _reset_metrics_provider() -> None:
+    global _provider
+
+    _provider = _NOOP_PROVIDER
+    with _gauge_lock:
+        _session_count_state.clear()
+        _session_max_state.clear()
+
+
+def is_metrics_operation_name(name: str) -> bool:
+    return _operation_name(name) in _CLIENT_OPERATION_NAMES
+
+
+def next_query_session_pool_name() -> str:
+    """Return a process-unique default query session pool name for metric labels."""
+    return "query-session-pool-%d" % next(_pool_name_counter)
+
+
+def query_session_pool_name(
+    name: Optional[str],
+    endpoint: Optional[str] = None,
+    database: Optional[str] = None,
+) -> str:
+    """Return a stable label for the ``ydb.query.session.pool.name`` metric attribute.
+
+    If the user passed an explicit ``name`` to ``QuerySessionPool``, it wins. Otherwise
+    the SDK builds a YDB connection string in the canonical ``<endpoint><database>``
+    form (e.g. ``grpc://localhost:2136/local``) so that the pool is identifiable in
+    dashboards without leaking driver-internal counters. When neither piece of the
+    connection string is available, a process-unique counter name is used as a last
+    resort.
+    """
+    if name:
+        return name
+    endpoint_part = endpoint or ""
+    database_part = database or ""
+    if database_part and not database_part.startswith("/"):
+        database_part = "/" + database_part
+    connection_string = endpoint_part + database_part
+    if connection_string:
+        return connection_string
+    return next_query_session_pool_name()
+
+
+def _metrics_build_info_tokens() -> List[str]:
+    """Metrics' contribution to the ``x-ydb-sdk-build-info`` header.
+
+    Returns ``["ydb-sdk-metrics/0.1.0"]`` once a metrics backend is installed,
+    otherwise an empty list. Aggregated with other features by
+    :func:`ydb.observability.sdk_build_info_tokens`.
+    """
+    return [METRICS_SDK_BUILD_INFO] if is_metrics_enabled() else []
+
+
+def _pool_attrs(pool_name: Optional[str]) -> Dict[str, Any]:
+    return {"ydb.query.session.pool.name": pool_name or _UNKNOWN_POOL}
+
+
+def _build_ydb_metrics_attrs(driver_config) -> Dict[str, Any]:
+    host, port = split_endpoint(getattr(driver_config, "endpoint", None))
+    endpoint = "%s:%d" % (host, port) if port else host
+    return {
+        "database": getattr(driver_config, "database", None) or "",
+        "endpoint": endpoint,
+    }
+
+
+def _operation_name(operation_name: str) -> str:
+    return _CLIENT_OPERATION_NAME_BY_INPUT.get(operation_name, operation_name)
+
+
+def _operation_attrs(operation_name: str, attributes: Dict[str, Any]) -> Dict[str, Any]:
+    name = _operation_name(operation_name)
+    return {
+        "database": attributes.get("database", ""),
+        "endpoint": attributes.get("endpoint", ""),
+        "operation.name": name,
+    }
+
+
+def _response_status_code(exception: BaseException) -> str:
+    status = getattr(exception, "status", None)
+    if status is not None:
+        return getattr(status, "name", str(status))
+    return type(exception).__qualname__
+
+
+class MetricsOperation:
+    """Metric lifecycle object for one user-visible YDB client operation.
+
+    ``MetricsOperation`` mirrors the small span-like interface used by tracing
+    so both can be composed by ``create_ydb_span``. It records operation
+    duration once, records a failed-operation counter when an exception is
+    attached, and accepts only stable operation labels.
+    """
+
+    def __init__(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
+        self._name = name
+        self._attributes = _operation_attrs(name, attributes or {})
+        self._start_time = time.monotonic()
+        self._exception: Optional[BaseException] = None
+        self._ended = False
+        self._end_lock = threading.Lock()
+
+    def set_error(self, exception: BaseException) -> None:
+        """Remember the operation exception for the failed-operation metric."""
+        self._exception = exception
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Set a metric label only when it is part of the operation metric contract."""
+        if key in _OPERATION_ATTR_KEYS:
+            self._attributes[key] = value
+
+    def attach_context(self, end_on_exit=True) -> "_MetricsOperationContext":
+        return _MetricsOperationContext(self, end_on_exit)
+
+    def end(self) -> None:
+        with self._end_lock:
+            if self._ended:
+                return
+            self._ended = True
+
+        duration = time.monotonic() - self._start_time
+        _provider.record(CLIENT_OPERATION_DURATION, duration, self._attributes)
+
+        if self._exception is not None:
+            attrs = dict(self._attributes)
+            attrs["status_code"] = _response_status_code(self._exception)
+            _provider.add(CLIENT_OPERATION_FAILED, 1, attrs)
+
+    def __enter__(self) -> "MetricsOperation":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is not None:
+            self.set_error(exc_val)
+        self.end()
+        return False
+
+
+class _NoopMetricsOperation:
+    def set_error(self, exception: BaseException) -> None:
+        pass
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def attach_context(self, end_on_exit=True) -> "_NoopMetricsOperationContext":
+        return _NoopMetricsOperationContext(self)
+
+    def end(self) -> None:
+        pass
+
+    def __enter__(self) -> "_NoopMetricsOperation":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+class _NoopMetricsOperationContext:
+    def __init__(self, operation: _NoopMetricsOperation) -> None:
+        self._operation = operation
+
+    def __enter__(self) -> _NoopMetricsOperation:
+        return self._operation
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+class _MetricsOperationContext:
+    """Context manager that optionally leaves ``end()`` to a streaming result iterator."""
+
+    def __init__(self, operation: MetricsOperation, end_on_exit: bool) -> None:
+        self._operation = operation
+        self._end_on_exit = end_on_exit
+
+    def __enter__(self) -> MetricsOperation:
+        return self._operation
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is not None:
+            self._operation.set_error(exc_val)
+            self._operation.end()
+        elif self._end_on_exit:
+            self._operation.end()
+        return False
+
+
+_NOOP_METRICS_OPERATION = _NoopMetricsOperation()
+
+
+def create_metrics_operation(name: str, attributes: Optional[Dict[str, Any]] = None):
+    if _provider is _NOOP_PROVIDER or _operation_name(name) not in _CLIENT_OPERATION_NAMES:
+        return _NOOP_METRICS_OPERATION
+    return MetricsOperation(name, attributes)
+
+
+def record_query_session_count(delta: int, pool_name: Optional[str] = None, state: str = "used") -> None:
+    if not is_metrics_enabled():
+        return
+    attrs = _pool_attrs(pool_name)
+    attrs["ydb.query.session.state"] = state
+    key = tuple(sorted(attrs.items()))
+    with _gauge_lock:
+        _session_count_state[key] = _session_count_state.get(key, 0) + delta
+
+
+def record_query_session_create_time(duration: float, pool_name: Optional[str]) -> None:
+    if not is_metrics_enabled():
+        return
+    _provider.record(QUERY_SESSION_CREATE_TIME, duration, _pool_attrs(pool_name))
+
+
+def record_query_session_pending_requests(delta: int, pool_name: Optional[str]) -> None:
+    if not is_metrics_enabled():
+        return
+    _provider.add(QUERY_SESSION_PENDING_REQUESTS, delta, _pool_attrs(pool_name))
+
+
+def record_query_session_timeout(pool_name: Optional[str]) -> None:
+    if not is_metrics_enabled():
+        return
+    _provider.add(QUERY_SESSION_TIMEOUTS, 1, _pool_attrs(pool_name))
+
+
+def record_query_session_max(value: int, pool_name: Optional[str]) -> None:
+    if not is_metrics_enabled():
+        return
+    key = tuple(sorted(_pool_attrs(pool_name).items()))
+    with _gauge_lock:
+        _session_max_state[key] = value
+
+
+def remove_query_session_pool_metrics(pool_name: Optional[str]) -> None:
+    if not is_metrics_enabled():
+        return
+    base = list(_pool_attrs(pool_name).items())
+    max_key = tuple(sorted(base))
+    idle_key = tuple(sorted(base + [("ydb.query.session.state", "idle")]))
+    used_key = tuple(sorted(base + [("ydb.query.session.state", "used")]))
+    with _gauge_lock:
+        _session_count_state.pop(idle_key, None)
+        _session_count_state.pop(used_key, None)
+        _session_max_state.pop(max_key, None)
+
+
+def record_retry_metrics(duration: float, attempts: int) -> None:
+    if not is_metrics_enabled():
+        return
+    _provider.record(RETRY_DURATION, duration)
+    _provider.record(RETRY_ATTEMPTS, attempts)
+
+
+class _NoopContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+_NOOP_CM = _NoopContext()
+
+
+class SessionMetrics:
+    """Per-session query-session-count bookkeeping, kept out of the session's own code.
+
+    Every :class:`~ydb.query.session.BaseQuerySession` owns one. It counts the session
+    as open exactly once and decrements the same bucket on close; the pool updates
+    :attr:`state` and :attr:`pool_name` as the session moves between idle and used.
+    """
+
+    __slots__ = ("pool_name", "state", "_counted")
+
+    def __init__(self) -> None:
+        self.pool_name: Optional[str] = None
+        self.state: str = "used"
+        self._counted = False
+
+    def count_open(self) -> None:
+        if self._counted:
+            return
+        self._counted = True
+        record_query_session_count(1, self.pool_name, self.state)
+
+    def count_closed(self) -> None:
+        if not self._counted:
+            return
+        self._counted = False
+        record_query_session_count(-1, self.pool_name, self.state)
+
+
+class _NoopSessionMetrics(SessionMetrics):
+    """Class-level default so sessions built bypassing ``__init__`` (in tests) stay safe."""
+
+    def count_open(self) -> None:
+        pass
+
+    def count_closed(self) -> None:
+        pass
+
+
+_NOOP_SESSION_METRICS = _NoopSessionMetrics()
+
+
+class _CreateTimer:
+    __slots__ = ("_pool_name", "_start")
+
+    def __init__(self, pool_name: Optional[str]) -> None:
+        self._pool_name = pool_name
+        self._start = 0.0
+
+    def __enter__(self):
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        record_query_session_create_time(time.monotonic() - self._start, self._pool_name)
+        return False
+
+
+class _PendingTracker:
+    __slots__ = ("_pool_name",)
+
+    def __init__(self, pool_name: Optional[str]) -> None:
+        self._pool_name = pool_name
+
+    def __enter__(self):
+        record_query_session_pending_requests(1, self._pool_name)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        record_query_session_pending_requests(-1, self._pool_name)
+        return False
+
+
+class QuerySessionPoolMetrics:
+    """All metric bookkeeping for one query session pool, hidden from the pool code.
+
+    The pool holds one instance and calls semantically named methods; timing and
+    counters live here, and stay cheap no-ops while metrics are disabled.
+    """
+
+    def __init__(self, name: Optional[str], driver, size: int) -> None:
+        driver_config = getattr(driver, "_driver_config", None)
+        self._pool_name = query_session_pool_name(
+            name,
+            endpoint=getattr(driver_config, "endpoint", None),
+            database=getattr(driver_config, "database", None),
+        )
+        record_query_session_max(size, self._pool_name)
+
+    def attach(self, session) -> None:
+        """Bind this pool's label to a freshly created session."""
+        session._session_metrics.pool_name = self._pool_name
+        session._session_metrics.state = "used"
+
+    def measure_create(self):
+        """Context manager recording query session creation time (no-op when disabled)."""
+        return _CreateTimer(self._pool_name) if is_metrics_enabled() else _NOOP_CM
+
+    def track_pending(self):
+        """Context manager counting a request waiting for a session (no-op when disabled)."""
+        return _PendingTracker(self._pool_name) if is_metrics_enabled() else _NOOP_CM
+
+    def on_timeout(self) -> None:
+        record_query_session_timeout(self._pool_name)
+
+    def on_acquired(self, session) -> None:
+        self._transition(session, "used")
+
+    def on_released(self, session) -> None:
+        self._transition(session, "idle")
+
+    def _transition(self, session, new_state: str) -> None:
+        session_metrics = session._session_metrics
+        record_query_session_count(-1, self._pool_name, session_metrics.state)
+        record_query_session_count(1, self._pool_name, new_state)
+        session_metrics.state = new_state
+
+    def close(self) -> None:
+        remove_query_session_pool_metrics(self._pool_name)
+
+
+class _RetryMetrics:
+    __slots__ = ("_start", "_attempts")
+
+    def __init__(self) -> None:
+        self._start = time.monotonic()
+        self._attempts = 0
+
+    def count(self, callee: Callable) -> Callable:
+        """Wrap *callee* so each invocation counts as one retry attempt."""
+        if inspect.iscoroutinefunction(callee):
+
+            @functools.wraps(callee)
+            async def acounted(*args, **kwargs):
+                self._attempts += 1
+                return await callee(*args, **kwargs)
+
+            return acounted
+
+        @functools.wraps(callee)
+        def counted(*args, **kwargs):
+            self._attempts += 1
+            return callee(*args, **kwargs)
+
+        return counted
+
+    def finish(self) -> None:
+        record_retry_metrics(time.monotonic() - self._start, self._attempts)
+
+
+def observe_retry_metrics(retry_func: Callable) -> Callable:
+    """Decorator recording retry duration and attempt count around a retry helper.
+
+    Wraps the retried callee to count attempts and times the whole operation — but only
+    while metrics are enabled, so the retry hot path is otherwise left untouched (no
+    ``time.monotonic`` calls, no wrappers).
+    """
+    if inspect.iscoroutinefunction(retry_func):
+
+        @functools.wraps(retry_func)
+        async def awrapper(callee, retry_settings=None, *args, **kwargs):
+            if not is_metrics_enabled():
+                return await retry_func(callee, retry_settings, *args, **kwargs)
+            metrics = _RetryMetrics()
+            try:
+                return await retry_func(metrics.count(callee), retry_settings, *args, **kwargs)
+            finally:
+                metrics.finish()
+
+        return awrapper
+
+    @functools.wraps(retry_func)
+    def wrapper(callee, retry_settings=None, *args, **kwargs):
+        if not is_metrics_enabled():
+            return retry_func(callee, retry_settings, *args, **kwargs)
+        metrics = _RetryMetrics()
+        try:
+            return retry_func(metrics.count(callee), retry_settings, *args, **kwargs)
+        finally:
+            metrics.finish()
+
+    return wrapper

--- a/ydb/observability/tracing.py
+++ b/ydb/observability/tracing.py
@@ -10,6 +10,9 @@ provider is installed everything is a no-op — the SDK never depends on
 import enum
 from typing import Any, Callable, ContextManager, Iterable, List, Optional, Protocol, Tuple
 
+from ydb.observability import metrics as _metrics
+from ydb.observability._endpoint import split_endpoint as _split_endpoint
+
 
 class SpanName(str, enum.Enum):
     """Canonical span names used across the YDB SDK."""
@@ -159,26 +162,6 @@ def _tracing_build_info_tokens() -> List[str]:
     return [TRACING_SDK_BUILD_INFO] if _registry.is_active() else []
 
 
-def _split_endpoint(endpoint: Optional[str]) -> Tuple[str, int]:
-    ep = endpoint or ""
-    if ep.startswith("grpcs://"):
-        ep = ep[len("grpcs://") :]
-    elif ep.startswith("grpc://"):
-        ep = ep[len("grpc://") :]
-
-    if ep.startswith("["):
-        close = ep.find("]")
-        if close != -1 and len(ep) > close + 1 and ep[close + 1] == ":":
-            host = ep[: close + 1]
-            port_s = ep[close + 2 :]
-            return host, int(port_s) if port_s.isdigit() else 0
-
-    host, sep, port_s = ep.rpartition(":")
-    if not sep:
-        return ep, 0
-    return host, int(port_s) if port_s.isdigit() else 0
-
-
 def _build_ydb_attrs(driver_config, node_id=None, peer=None):
     host, port = _split_endpoint(getattr(driver_config, "endpoint", None))
     attrs = {
@@ -205,16 +188,74 @@ def create_span(name, attributes=None, kind="internal"):
     return _registry.create_span(name, attributes=attributes, kind=kind).attach_context()
 
 
-def create_ydb_span(name, driver_config, node_id=None, kind=None, peer=None) -> Span:
-    """Create a span pre-filled with standard YDB attributes.
+class _TelemetryContext:
+    """Attach tracing context and metrics lifecycle for one SDK operation."""
 
-    When no provider is active a :class:`NoopSpan` is returned so callers can
-    call ``.attach_context()``, ``.set_attribute(...)`` etc. unconditionally.
+    def __init__(self, telemetry, span_context, metrics_context):
+        self._telemetry = telemetry
+        self._span_context = span_context
+        self._metrics_context = metrics_context
+
+    def __enter__(self):
+        self._metrics_context.__enter__()
+        self._span_context.__enter__()
+        return self._telemetry
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        span_result = self._span_context.__exit__(exc_type, exc_val, exc_tb)
+        metrics_result = self._metrics_context.__exit__(exc_type, exc_val, exc_tb)
+        return bool(span_result or metrics_result)
+
+
+class _TelemetryOperation:
+    """Span-compatible facade that forwards lifecycle events to tracing and metrics."""
+
+    def __init__(self, span, metrics):
+        self._span = span
+        self._metrics = metrics
+
+    def set_error(self, exception):
+        self._span.set_error(exception)
+        self._metrics.set_error(exception)
+
+    def set_attribute(self, key, value):
+        self._span.set_attribute(key, value)
+        self._metrics.set_attribute(key, value)
+
+    def end(self):
+        self._span.end()
+        self._metrics.end()
+
+    def attach_context(self, end_on_exit=True):
+        return _TelemetryContext(
+            self,
+            self._span.attach_context(end_on_exit=end_on_exit),
+            self._metrics.attach_context(end_on_exit=end_on_exit),
+        )
+
+
+def create_ydb_span(name, driver_config, node_id=None, kind=None, peer=None) -> Span:
+    """Create telemetry for one user-visible YDB client operation.
+
+    The returned object is span-compatible: when tracing is active it carries the
+    standard YDB attributes, and when metrics are active the same object also drives
+    the client operation metrics. When neither is active a shared :class:`NoopSpan`
+    is returned so callers can use ``.attach_context()``, ``.set_attribute(...)``
+    etc. unconditionally with zero overhead.
     """
-    if not _registry.is_active():
+    tracing_active = _registry.is_active()
+    metrics_active = _metrics.is_metrics_enabled()
+    if not tracing_active and not metrics_active:
         return NoopTracingProvider._SPAN
-    attrs = _build_ydb_attrs(driver_config, node_id, peer)
-    return _registry.create_span(name, attributes=attrs, kind=kind)
+
+    if tracing_active:
+        span = _registry.create_span(name, attributes=_build_ydb_attrs(driver_config, node_id, peer), kind=kind)
+    else:
+        span = NoopTracingProvider._SPAN
+
+    metrics_attrs = _metrics._build_ydb_metrics_attrs(driver_config) if metrics_active else None
+    metrics = _metrics.create_metrics_operation(name, metrics_attrs)
+    return _TelemetryOperation(span, metrics)
 
 
 def set_peer_attributes(span: Span, peer) -> None:

--- a/ydb/opentelemetry/__init__.py
+++ b/ydb/opentelemetry/__init__.py
@@ -1,9 +1,9 @@
 """Public OpenTelemetry entrypoints for YDB.
 
-For vendor-neutral tracing (custom providers, Noop, interfaces) see
+For vendor-neutral tracing and metrics (custom backends, Noop, interfaces) see
 :mod:`ydb.observability`. This module is a convenience wrapper that constructs
-an OpenTelemetry-backed provider and installs it via
-:func:`ydb.observability.enable_tracing`.
+OpenTelemetry-backed backends and installs them via
+:func:`ydb.observability.enable_tracing` / :func:`ydb.observability.enable_metrics`.
 """
 
 
@@ -38,23 +38,69 @@ def disable_tracing():
     _disable_tracing()
 
 
+def enable_metrics(meter_provider=None):
+    """Enable OpenTelemetry metrics collection for YDB SDK client metrics.
+
+    This call is **idempotent**: if metrics are already enabled, later calls do nothing
+    (including passing a different ``meter_provider``). Call :func:`disable_metrics`
+    first to reconfigure or turn instrumentation off.
+
+    Args:
+        meter_provider: Optional OTel meter provider to use. If not provided, the
+            default meter named ``ydb.sdk`` from the global meter provider will be used.
+    """
+    try:
+        from ydb.opentelemetry.metrics_plugin import _enable_metrics
+    except ImportError:
+        raise ImportError(
+            "OpenTelemetry packages are required for metrics support. "
+            "Install them with: pip install ydb[opentelemetry]"
+        ) from None
+
+    _enable_metrics(meter_provider)
+
+
+def disable_metrics():
+    """Disable YDB OpenTelemetry metrics collection and allow :func:`enable_metrics` to run again."""
+    try:
+        from ydb.opentelemetry.metrics_plugin import _disable_metrics
+    except ImportError:
+        return
+
+    _disable_metrics()
+
+
+_LAZY_PROVIDERS = {
+    "OtelTracingProvider": ("ydb.opentelemetry.plugin", "OtelTracingProvider"),
+    "OtelMetricsProvider": ("ydb.opentelemetry.metrics_plugin", "OtelMetricsProvider"),
+}
+
+
 def __getattr__(name):
-    # Lazily expose the OTel provider so ``from ydb.opentelemetry import
+    # Lazily expose the OTel backends so ``from ydb.opentelemetry import
     # OtelTracingProvider`` works without importing ``opentelemetry`` at module
     # load time. When OTel is missing, raise AttributeError (not ImportError) so
     # hasattr()/getattr(..., default) introspection behaves normally; the install
-    # hint rides along in the message, and enable_tracing() keeps its own
-    # ImportError guidance for the primary entrypoint.
-    if name == "OtelTracingProvider":
+    # hint rides along in the message, and enable_tracing()/enable_metrics() keep
+    # their own ImportError guidance for the primary entrypoints.
+    target = _LAZY_PROVIDERS.get(name)
+    if target is not None:
+        module_name, attr = target
         try:
-            from ydb.opentelemetry.plugin import OtelTracingProvider
+            module = __import__(module_name, fromlist=[attr])
         except ImportError:
             raise AttributeError(
-                "OtelTracingProvider requires the OpenTelemetry packages. "
-                "Install them with: pip install ydb[opentelemetry]"
+                f"{name} requires the OpenTelemetry packages. " "Install them with: pip install ydb[opentelemetry]"
             ) from None
-        return OtelTracingProvider
+        return getattr(module, attr)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["OtelTracingProvider", "disable_tracing", "enable_tracing"]
+__all__ = [
+    "OtelMetricsProvider",
+    "OtelTracingProvider",
+    "disable_metrics",
+    "disable_tracing",
+    "enable_metrics",
+    "enable_tracing",
+]

--- a/ydb/opentelemetry/metrics_plugin.py
+++ b/ydb/opentelemetry/metrics_plugin.py
@@ -1,0 +1,187 @@
+"""OpenTelemetry metrics adapter for the YDB observability interface.
+
+Implements :class:`ydb.observability.MetricsProvider` on top of the ``opentelemetry``
+packages. The SDK core does not import it — the OTel dependency is only pulled in when a
+user calls :func:`ydb.opentelemetry.enable_metrics`.
+"""
+
+from typing import Any, Dict, Optional
+
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.metrics import (
+    CallbackOptions,
+    Histogram,
+    Meter,
+    MeterProvider,
+    Observation,
+)
+
+from ydb.observability import enable_metrics as _observability_enable_metrics
+from ydb.observability import disable_metrics as _observability_disable_metrics
+from ydb.observability.metrics import (
+    CLIENT_OPERATION_DURATION,
+    CLIENT_OPERATION_FAILED,
+    QUERY_SESSION_COUNT,
+    QUERY_SESSION_CREATE_TIME,
+    QUERY_SESSION_MAX,
+    QUERY_SESSION_MIN,
+    QUERY_SESSION_PENDING_REQUESTS,
+    QUERY_SESSION_TIMEOUTS,
+    RETRY_ATTEMPTS,
+    RETRY_DURATION,
+    ATTEMPT_BUCKETS,
+    DURATION_BUCKETS_SECONDS,
+    GaugeCallback,
+    RETRY_DURATION_BUCKETS_SECONDS,
+)
+
+_meter: Optional[Meter] = None
+
+# Unit/description for the asynchronous gauges the SDK registers via observe_gauge.
+_GAUGE_META = {
+    QUERY_SESSION_COUNT: ("{connection}", "Number of open YDB query sessions."),
+    QUERY_SESSION_MAX: ("{connection}", "Maximum configured number of YDB query sessions."),
+    QUERY_SESSION_MIN: ("{connection}", "Minimum configured number of YDB query sessions."),
+}
+
+
+class OtelMetricsProvider:
+    """OpenTelemetry-backed :class:`ydb.observability.MetricsProvider`.
+
+    Push instruments (histograms, counters) are created eagerly with the SDK's
+    units/buckets; asynchronous gauges are created lazily via :meth:`observe_gauge`.
+    """
+
+    def __init__(self, meter: Meter) -> None:
+        self._meter = meter
+        self._histograms: Dict[str, Histogram] = {
+            CLIENT_OPERATION_DURATION: _create_histogram(
+                meter,
+                CLIENT_OPERATION_DURATION,
+                unit="s",
+                description="Duration of YDB client operations.",
+                bucket_boundaries=DURATION_BUCKETS_SECONDS,
+            ),
+            QUERY_SESSION_CREATE_TIME: _create_histogram(
+                meter,
+                QUERY_SESSION_CREATE_TIME,
+                unit="s",
+                description="Duration of YDB query session creation.",
+                bucket_boundaries=DURATION_BUCKETS_SECONDS,
+            ),
+            RETRY_DURATION: _create_histogram(
+                meter,
+                RETRY_DURATION,
+                unit="s",
+                description=(
+                    "Total user-visible duration of a logical operation executed through the retry policy, "
+                    "including all attempts and back-off delays."
+                ),
+                bucket_boundaries=RETRY_DURATION_BUCKETS_SECONDS,
+            ),
+            RETRY_ATTEMPTS: _create_histogram(
+                meter,
+                RETRY_ATTEMPTS,
+                unit="{attempt}",
+                description=(
+                    "Total number of attempts performed by the retry policy for one logical operation. "
+                    "A value of 1 means the operation succeeded on the first try."
+                ),
+                bucket_boundaries=ATTEMPT_BUCKETS,
+            ),
+        }
+        self._counters: Dict[str, Any] = {
+            CLIENT_OPERATION_FAILED: meter.create_counter(
+                CLIENT_OPERATION_FAILED,
+                unit="{command}",
+                description="Number of failed YDB client operations.",
+            ),
+            QUERY_SESSION_TIMEOUTS: meter.create_counter(
+                QUERY_SESSION_TIMEOUTS,
+                unit="{connection}",
+                description="Number of YDB query session acquisition timeouts.",
+            ),
+            QUERY_SESSION_PENDING_REQUESTS: meter.create_up_down_counter(
+                QUERY_SESSION_PENDING_REQUESTS,
+                unit="{request}",
+                description="Number of requests waiting for a YDB query session.",
+            ),
+        }
+
+    def record(self, name: str, value: float, attributes: Optional[Dict[str, Any]] = None) -> None:
+        instrument = self._histograms.get(name)
+        if instrument is not None:
+            instrument.record(value, attributes=attributes or {})
+
+    def add(self, name: str, value: int, attributes: Optional[Dict[str, Any]] = None) -> None:
+        instrument = self._counters.get(name)
+        if instrument is not None:
+            instrument.add(value, attributes=attributes or {})
+
+    def observe_gauge(self, name: str, callback: GaugeCallback) -> None:
+        unit, description = _GAUGE_META.get(name, ("", ""))
+
+        def _otel_callback(_: CallbackOptions):
+            return [Observation(value, attributes=attrs) for value, attrs in callback()]
+
+        self._meter.create_observable_up_down_counter(
+            name,
+            callbacks=[_otel_callback],
+            unit=unit,
+            description=description,
+        )
+
+
+def _enable_metrics(meter_provider: Optional[MeterProvider]) -> None:
+    """Build an :class:`OtelMetricsProvider` from an OTel MeterProvider and install it.
+
+    Called by :func:`ydb.opentelemetry.enable_metrics`. Idempotent: if metrics are
+    already enabled the call is a no-op (re-registering OpenTelemetry observable
+    callbacks would double-count). Call :func:`ydb.opentelemetry.disable_metrics`
+    first to reconfigure.
+    """
+    global _meter
+
+    if _meter is not None:
+        return
+
+    if meter_provider is None:
+        _meter = otel_metrics.get_meter("ydb.sdk")
+    elif hasattr(meter_provider, "get_meter"):
+        _meter = meter_provider.get_meter("ydb.sdk")
+    else:
+        raise TypeError("meter_provider must be an OpenTelemetry MeterProvider")
+
+    _observability_enable_metrics(OtelMetricsProvider(_meter))
+
+
+def _disable_metrics() -> None:
+    global _meter
+
+    _observability_disable_metrics()
+    _meter = None
+
+
+def _create_histogram(
+    meter: Meter,
+    name: str,
+    unit: str,
+    description: str,
+    bucket_boundaries,
+) -> Histogram:
+    """Create a histogram with bucket advice when the installed OpenTelemetry SDK supports it."""
+    try:
+        return meter.create_histogram(
+            name,
+            unit=unit,
+            description=description,
+            explicit_bucket_boundaries_advisory=bucket_boundaries,
+        )
+    except TypeError as e:
+        if "explicit_bucket_boundaries_advisory" not in str(e):
+            raise
+        return meter.create_histogram(
+            name,
+            unit=unit,
+            description=description,
+        )

--- a/ydb/query/pool.py
+++ b/ydb/query/pool.py
@@ -27,6 +27,7 @@ from ..retries import (
 from .. import issues
 from .. import convert
 from ..settings import BaseRequestSettings
+from ..observability.metrics import QuerySessionPoolMetrics
 from .._grpc.grpcwrapper import ydb_query_public_types as _ydb_query_public
 
 if TYPE_CHECKING:
@@ -47,12 +48,14 @@ class QuerySessionPool:
         *,
         query_client_settings: Optional[QueryClientSettings] = None,
         workers_threads_count: int = 4,
+        name: Optional[str] = None,
     ):
         """
         :param driver: A driver instance.
         :param size: Max size of Session Pool.
         :param query_client_settings: ydb.QueryClientSettings object to configure QueryService behavior
         :param workers_threads_count: A number of threads in executor used for ``*_async`` methods
+        :param name: Optional session pool name for observability metrics.
         """
 
         self._driver = driver
@@ -63,10 +66,13 @@ class QuerySessionPool:
         self._should_stop = threading.Event()
         self._lock = threading.RLock()
         self._query_client_settings = query_client_settings
+        self._metrics = QuerySessionPoolMetrics(name, driver, self._size)
 
     def _create_new_session(self, timeout: Optional[float]):
         session = QuerySession(self._driver, settings=self._query_client_settings)
-        session.create(settings=BaseRequestSettings().with_timeout(timeout))
+        self._metrics.attach(session)
+        with self._metrics.measure_create():
+            session.create(settings=BaseRequestSettings().with_timeout(timeout))
         logger.debug(f"New session was created for pool. Session id: {session.session_id}")
         return session
 
@@ -95,17 +101,20 @@ class QuerySessionPool:
                 pass
 
             finish = time.monotonic()
-            timeout = timeout - (finish - start) if timeout is not None else None
+            timeout = max(0, timeout - (finish - start)) if timeout is not None else None
 
             start = time.monotonic()
             if session is None and self._current_size == self._size:
-                try:
-                    session = self._queue.get(block=True, timeout=timeout)
-                except queue.Empty:
-                    raise issues.SessionPoolEmpty("Timeout on acquire session")
+                with self._metrics.track_pending():
+                    try:
+                        session = self._queue.get(block=True, timeout=timeout)
+                    except queue.Empty:
+                        self._metrics.on_timeout()
+                        raise issues.SessionPoolEmpty("Timeout on acquire session")
 
             if session is not None:
                 if session.is_active:
+                    self._metrics.on_acquired(session)
                     logger.debug(f"Acquired active session from queue: {session.session_id}")
                     return session
                 else:
@@ -114,7 +123,7 @@ class QuerySessionPool:
 
             logger.debug(f"Session pool is not large enough: {self._current_size} < {self._size}, will create new one.")
             finish = time.monotonic()
-            time_left = timeout - (finish - start) if timeout is not None else None
+            time_left = max(0, timeout - (finish - start)) if timeout is not None else None
             session = self._create_new_session(time_left)
 
             self._current_size += 1
@@ -125,6 +134,7 @@ class QuerySessionPool:
 
     def release(self, session: QuerySession) -> None:
         """Release a session back to Session Pool."""
+        self._metrics.on_released(session)
         self._queue.put_nowait(session)
         logger.debug("Session returned to queue: %s", session.session_id)
 
@@ -317,6 +327,7 @@ class QuerySessionPool:
                     break
 
             logger.debug("All session were deleted.")
+            self._metrics.close()
         finally:
             if acquired:
                 self._lock.release()

--- a/ydb/query/session.py
+++ b/ydb/query/session.py
@@ -19,6 +19,7 @@ from .base import QueryExplainResultFormat
 
 from .. import _apis, issues, _utilities
 from ..observability.tracing import SpanName, create_ydb_span, set_peer_attributes, span_finish_callback
+from ..observability.metrics import SessionMetrics, _NOOP_SESSION_METRICS
 from ..settings import BaseRequestSettings
 from ..connection import _RpcState as RpcState, EndpointKey
 from .._grpc.grpcwrapper import common_utils
@@ -94,6 +95,7 @@ class BaseQuerySession(abc.ABC, Generic[DriverT]):
     _peer: Optional[tuple] = None
     _closed: bool = False
     _invalidated: bool = False
+    _session_metrics: SessionMetrics = _NOOP_SESSION_METRICS
 
     def __init__(self, driver: DriverT, settings: Optional[base.QueryClientSettings] = None):
         self._driver = driver
@@ -106,6 +108,7 @@ class BaseQuerySession(abc.ABC, Generic[DriverT]):
         )
 
         self._last_query_stats = None
+        self._session_metrics = SessionMetrics()
 
     @property
     def _driver_config(self) -> Optional["DriverConfig"]:
@@ -177,6 +180,7 @@ class BaseQuerySession(abc.ABC, Generic[DriverT]):
     def _close_session(self, invalidate: bool = False) -> None:
         if self._closed:
             return
+        self._session_metrics.count_closed()
         if invalidate:
             self._invalidated = True
         self._closed = True
@@ -440,6 +444,7 @@ class QuerySession(BaseQuerySession["SyncDriver"]):
             self._create_call(settings=settings)
             set_peer_attributes(span, self._peer)
             self._attach()
+            self._session_metrics.count_open()
 
         return self
 

--- a/ydb/retries.py
+++ b/ydb/retries.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Generator, Optional, Union
 
 from . import issues
 from ._errors import check_retriable_error
+from .observability.metrics import observe_retry_metrics
 from .observability.tracing import SpanName, create_span as _create_span
 
 
@@ -157,6 +158,7 @@ def retry_operation_impl(
         raise status
 
 
+@observe_retry_metrics
 def retry_operation_sync(
     callee: Callable[..., Any],
     retry_settings: Optional[RetrySettings] = None,
@@ -181,6 +183,7 @@ def retry_operation_sync(
     return None
 
 
+@observe_retry_metrics
 async def retry_operation_async(  # pylint: disable=W1113
     callee: Callable[..., Any],
     retry_settings: Optional[RetrySettings] = None,
@@ -200,19 +203,23 @@ async def retry_operation_async(  # pylint: disable=W1113
     Returns awaitable result of coroutine. If retries are not succussful exception is raised.
     """
     backoff_ms: Optional[int] = None
+
+    @functools.wraps(callee)
+    async def traced_callee(*a: Any, **kw: Any) -> Any:
+        with _create_span(SpanName.TRY, _try_span_attrs(backoff_ms)):
+            return await callee(*a, **kw)
+
     with _create_span(SpanName.RUN_WITH_RETRY):
-        for next_opt in retry_operation_impl(callee, retry_settings, *args, **kwargs):
+        for next_opt in retry_operation_impl(traced_callee, retry_settings, *args, **kwargs):
             if isinstance(next_opt, YdbRetryOperationSleepOpt):
                 backoff_ms = int(next_opt.timeout * 1000)
                 if next_opt.timeout > 0:
                     await asyncio.sleep(next_opt.timeout)
             else:
-                with _create_span(SpanName.TRY, _try_span_attrs(backoff_ms)) as try_span:
-                    try:
-                        return await next_opt.result
-                    except BaseException as e:  # pylint: disable=W0703
-                        try_span.set_error(e)
-                        next_opt.set_exception(e)
+                try:
+                    return await next_opt.result
+                except BaseException as e:  # pylint: disable=W0703
+                    next_opt.set_exception(e)
     return None
 
 


### PR DESCRIPTION
Reopens #824 for `main`, rebased on top of the vendor-neutral observability split (#861).

## Pull request type

- [x] Feature

## What is the current behavior?

The SDK exposes OpenTelemetry **tracing** through the vendor-neutral `ydb.observability` layer (#861), but has no client-side **metrics** for YDB operations, retries, or query session pools.

## What is the new behavior?

Adds client-side metrics on the same `ydb.observability` layer, symmetric with tracing — so OpenTelemetry is one backend and the SDK core never imports `opentelemetry`.

**Public API**

- `ydb.observability.enable_metrics(provider)` / `disable_metrics()` — vendor-neutral; any `MetricRegistry`-shaped backend works.
- `ydb.opentelemetry.enable_metrics(meter_provider=None)` / `disable_metrics()` — the OpenTelemetry convenience (builds an OTel-backed registry and installs it via the observability layer).
- `ydb.opentelemetry.OtelMetricsProvider` — lazily exposed for advanced wiring.
- `QuerySessionPool(..., name=...)` — optional pool name for the `ydb.query.session.pool.name` metric label.

**Instruments**

- `db.client.operation.duration` — client operation latency
- `ydb.client.operation.failed` — failed client operations
- `ydb.query.session.create_time` — session creation latency
- `ydb.query.session.pending_requests` — pool wait-queue size
- `ydb.query.session.timeouts` — session acquisition timeouts
- `ydb.query.session.count` — open sessions by pool and `idle`/`used`
- `ydb.query.session.max` — configured pool size
- `ydb.client.retry.duration` / `ydb.client.retry.attempts` — retry cost and attempt count

**Implementation notes**

- The metric machinery is kept **out of the query-service code**: all bookkeeping lives in `ydb.observability.metrics` behind `SessionMetrics`, `QuerySessionPoolMetrics` (with conditional timing context managers), and the `observe_retry_metrics` decorator. The pool/session/retry code carries only clean facade calls — no `time.monotonic`, attribute dicts, or `record_*` scattered inline, and no timing work at all while metrics are disabled.
- `create_ydb_span` returns a span-compatible composite that drives tracing and metrics for one operation without adding an extra span level (zero overhead when both are off).
- When metrics are enabled the SDK appends a `ydb-sdk-metrics/0.1.0` token to the `x-ydb-sdk-build-info` header (via the shared `sdk_build_info_tokens` aggregator).

Metrics are independent from tracing; enable either, both, or neither. Docs on the `observability` and `opentelemetry` pages are updated, and the OTel example exports both traces and metrics through OTLP.

## Other information

Observability tests are consolidated under `tests/observability/` (tracing + metrics), the latter using OpenTelemetry SDK in-memory metric readers. Verified with unit + integration tests against a live YDB and end-to-end through a real OTLP collector.

## Test plan

- [x] `tox -e black && tox -e style && tox -e mypy`
- [x] `tox -e py -- ydb tests/observability -v`
- [x] Integration: `tox -e py -- tests/query tests/aio tests/table` against a live YDB
- [x] End-to-end example export through an OTLP collector
