### PR TITLE
add matching selects to resultsets reference

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -378,6 +378,7 @@ statements).
     result_set.rows      # list of Row objects — access columns by name: row["col"]
     result_set.columns   # list of column descriptors with .name and .type
     result_set.truncated # True if the server truncated results (use pagination)
+    result_set.index     # sequence number of the SELECT statement in a multiple SELECT query
 
 .. note::
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Documentation content changes

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

When a query contains multiple SELECT statements, it may be unclear which ResultSet corresponds to which SELECT. This minor documentation change aims to bring clarity to this identification.
