### PR TITLE
Add native-sdk Codecov component

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,6 +8,16 @@ coverage:
       default:
         target: 80%        # new/changed code in the PR diff must be >= 80% covered
 
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk), regardless of how each repo tags its uploads.
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK
+      paths:
+        - "ydb/**"
+
 flags:
   unit:
     paths:


### PR DESCRIPTION
Defines a path-based `native-sdk` component (`ydb/**`) in codecov.yml.

Same `component_id` will be added across all YDB SDK repos so native-SDK coverage is queryable uniformly via the Codecov API (`?component_id=native-sdk`), independent of per-repo upload/flag setups.

No metric change here — `ignore` already scopes the report to native code, so `native-sdk` equals the current repo-level number.