### PR TITLE
Restore attribute assignment on query result set rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Restore attribute assignment on query result set rows (broken by the result set memory optimization)
+
 ## 3.29.5 ##
 * Fix gRPC thread leak on failed topic writer reconnect
 * Reduce memory usage of query service result sets

--- a/ydb/convert.py
+++ b/ydb/convert.py
@@ -24,7 +24,11 @@ _initialize()
 
 
 class _DotDict(dict):
-    __slots__ = ()
+    # A lazy __dict__ is declared on purpose: read-only rows never allocate one
+    # (the per-instance dict is the memory overhead we want to avoid), but
+    # callers may still attach their own attributes (ORM-style row.extra = ...),
+    # which materializes the dict for that row alone.
+    __slots__ = ("__dict__",)
 
     def __init__(self, *args, **kwargs):
         super(_DotDict, self).__init__(*args, **kwargs)

--- a/ydb/convert.py
+++ b/ydb/convert.py
@@ -24,10 +24,11 @@ _initialize()
 
 
 class _DotDict(dict):
-    # A lazy __dict__ is declared on purpose: read-only rows never allocate one
-    # (the per-instance dict is the memory overhead we want to avoid), but
-    # callers may still attach their own attributes (ORM-style row.extra = ...),
-    # which materializes the dict for that row alone.
+    # A lazy __dict__ is declared on purpose: it is not materialized until a row
+    # is written to (or its __dict__ is introspected), so untouched read-only
+    # rows avoid the per-instance dict overhead while callers can still attach
+    # their own attributes (ORM-style row.extra = ...), which materializes the
+    # dict for that row alone.
     __slots__ = ("__dict__",)
 
     def __init__(self, *args, **kwargs):

--- a/ydb/table_test.py
+++ b/ydb/table_test.py
@@ -58,6 +58,41 @@ def test_result_set_row_allows_attribute_assignment():
     assert row["column_0"] == 0
 
 
+def test_result_set_row_attribute_shadows_column():
+    # With a lazy __dict__, assigning an attribute that matches a column name
+    # shadows the column for attribute access (normal lookup finds __dict__
+    # before __getattr__ runs), while item access still reads the column value.
+    message = _build_int_result_set(n_rows=1, n_cols=3)
+    row = convert.ResultSet.from_message(message).rows[0]
+
+    row.column_0 = "override"
+    assert row.column_0 == "override"
+    assert row["column_0"] == 0
+
+    del row.column_0
+    assert row.column_0 == 0
+
+
+def test_lazy_result_set_row_allows_attribute_assignment():
+    # _LazyRow inherits the lazy __dict__ from _DotDict too.
+    message = _build_int_result_set(n_rows=1, n_cols=2)
+    row = convert.ResultSet.lazy_from_message(message).rows.fetchone()
+
+    row.dt_created = 123
+    assert row.dt_created == 123
+    assert row["column_0"] == 0
+
+
+def test_struct_value_allows_attribute_assignment():
+    # _Struct shares the lazy __dict__ from _DotDict.
+    struct = convert._Struct()
+    struct["a"] = 1
+
+    struct.computed = 2
+    assert struct.a == 1
+    assert struct.computed == 2
+
+
 def test_result_set_row_missing_attribute_raises_attribute_error():
     message = _build_int_result_set(n_rows=1, n_cols=1)
     row = convert.ResultSet.from_message(message).rows[0]

--- a/ydb/table_test.py
+++ b/ydb/table_test.py
@@ -37,12 +37,25 @@ def test_result_set_row_access():
     assert dict(row) == {"column_0": 0, "column_1": 1, "column_2": 2}
 
 
-def test_result_set_row_has_no_instance_dict():
-    # Rows must not carry a per-instance __dict__: it is pure memory overhead
-    # multiplied by every row in a large result set.
+def test_result_set_row_keeps_data_out_of_instance_dict():
+    # Column values live in the dict base and `_columns` in a slot, never in a
+    # per-instance __dict__ that would be multiplied across every row. The
+    # __dict__ is lazy and stays empty until a caller attaches its own attribute.
     message = _build_int_result_set(n_rows=1, n_cols=3)
     row = convert.ResultSet.from_message(message).rows[0]
-    assert not hasattr(row, "__dict__")
+    assert row.__dict__ == {}
+
+
+def test_result_set_row_allows_attribute_assignment():
+    # Rows expose a __dict__ so callers can attach computed fields onto them
+    # (ORM-style row.dt_created = ...); the memory optimization must keep that
+    # working while leaving read-only rows unburdened.
+    message = _build_int_result_set(n_rows=1, n_cols=3)
+    row = convert.ResultSet.from_message(message).rows[0]
+
+    row.dt_created = 123
+    assert row.dt_created == 123
+    assert row["column_0"] == 0
 
 
 def test_result_set_row_missing_attribute_raises_attribute_error():


### PR DESCRIPTION
## Problem
The result set memory optimization (#843) gave row/struct dict subclasses strict `__slots__`, dropping their `__dict__`. Code that attaches computed fields onto rows (e.g. `row.dt_created = ...`) now fails with `AttributeError: ... no __dict__ for setting new attributes`.

## Fix
Declare a **lazy** `__dict__` on `_DotDict` (`__slots__ = ("__dict__",)`). `_columns` stays a real slot and read-only rows allocate no per-instance dict, so the memory win of #843 is preserved (~99%); only rows callers write to materialize a dict.