### PR TITLE
SLO: async-query + topic (sync/async) workloads, label-driven, with delivery/ordering validation

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   publish-slo-report:
-    # SLO workflow runs on every PR event, but the job inside is gated
-    # on the "SLO" label. Without the label the matrix is skipped and the
-    # workflow conclusion is "skipped" — in that case there is nothing
-    # to publish and no label to remove.
-    if: github.event.workflow_run.conclusion != 'skipped'
+    # Only act on runs that actually executed to completion. A "skipped"
+    # conclusion means the matrix was gated out (no "SLO" label) — nothing to
+    # publish. A "cancelled" conclusion means the run was superseded mid-flight
+    # (e.g. by `cancel-in-progress` when a new run started) — there is no real
+    # report and the label must NOT be stripped, otherwise it gets removed long
+    # before the actual workload finishes. Success/failure are genuine endings.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
     name: Publish YDB SLO Report
     runs-on: ubuntu-latest
     permissions:
@@ -31,7 +35,12 @@ jobs:
           github_run_id: ${{ github.event.workflow_run.id }}
 
   remove-slo-label:
-    if: github.event.workflow_run.conclusion != 'skipped'
+    # Same gating as the report job: only consume the "SLO" label once a run has
+    # genuinely finished (success/failure). Removing it on a "cancelled" run
+    # would strip the label mid-flight when a run is superseded.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
     name: Remove SLO Label
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -120,27 +120,6 @@ jobs:
             -t "ydb-app-baseline" \
             "$GITHUB_WORKSPACE/sdk-baseline"
 
-      # TEMPORARY diagnostic (remove before merge): the YDB node image is built
-      # inside the action under `docker compose up --quiet-build`, so the pull of
-      # the cr.yandex base/stage images isn't visible in the log. Time it here on
-      # the runner. Side effect: pre-pulling warms the local store, so the
-      # action's build reuses these layers instead of re-pulling (~5 min build).
-      - name: (diag) time YDB base image pulls
-        continue-on-error: true
-        run: |
-          for img in \
-            cr.yandex/crpb3d0up7s6a7iuofo9/ydb-appteam-ci/local-ydb:stable-25-3 \
-            cr.yandex/crpb3d0up7s6a7iuofo9/ydb-appteam-ci/debian:bookworm-slim; do
-            s=$(date +%s)
-            if docker pull "$img" >/dev/null 2>&1; then
-              e=$(( $(date +%s) - s ))
-              bytes=$(docker image inspect "$img" --format '{{.Size}}' 2>/dev/null || echo 0)
-              echo "PULLED  $img  in ${e}s  size=$(( bytes / 1024 / 1024 ))MB"
-            else
-              echo "FAILED  $img  (auth/network) after $(( $(date +%s) - s ))s"
-            fi
-          done
-
       - name: Run SLO Tests
         uses: ydb-platform/ydb-slo-action/init@v2
         timeout-minutes: 30

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -33,6 +33,9 @@ jobs:
             command: "--read-rps 1000 --write-rps 100"
           - name: async-query
             command: "--read-rps 1000 --write-rps 100"
+          - name: async-topic
+            command: "--write-rps 100 --write-threads 2 --read-threads 2"
+            metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
 
     concurrency:
       group: slo-${{ github.ref }}-${{ matrix.sdk.name }}
@@ -134,3 +137,6 @@ jobs:
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline
           workload_baseline_command: ${{ matrix.sdk.command }}
+          # Custom metrics (e.g. topic e2e latency / loss) merged on top of the
+          # action defaults; empty for workloads that don't set it.
+          metrics_yaml_path: ${{ matrix.sdk.metrics_yaml_path }}

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -34,10 +34,10 @@ jobs:
           - name: async-query
             command: "--read-rps 1000 --write-rps 100"
           - name: sync-topic
-            command: "--write-rps 100 --write-threads 2 --read-threads 2"
+            command: "--write-rps 1000 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
           - name: async-topic
-            command: "--write-rps 100 --write-threads 2 --read-threads 2"
+            command: "--write-rps 1000 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
 
     concurrency:

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -34,10 +34,10 @@ jobs:
           - name: async-query
             command: "--read-rps 1000 --write-rps 100"
           - name: sync-topic
-            command: "--write-rps 1000 --write-threads 8 --read-threads 8"
+            command: "--write-rps 200 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
           - name: async-topic
-            command: "--write-rps 1000 --write-threads 8 --read-threads 8"
+            command: "--write-rps 200 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
 
     concurrency:

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -33,6 +33,9 @@ jobs:
             command: "--read-rps 1000 --write-rps 100"
           - name: async-query
             command: "--read-rps 1000 --write-rps 100"
+          - name: sync-topic
+            command: "--write-rps 100 --write-threads 2 --read-threads 2"
+            metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
           - name: async-topic
             command: "--write-rps 100 --write-threads 2 --read-threads 2"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -120,6 +120,27 @@ jobs:
             -t "ydb-app-baseline" \
             "$GITHUB_WORKSPACE/sdk-baseline"
 
+      # TEMPORARY diagnostic (remove before merge): the YDB node image is built
+      # inside the action under `docker compose up --quiet-build`, so the pull of
+      # the cr.yandex base/stage images isn't visible in the log. Time it here on
+      # the runner. Side effect: pre-pulling warms the local store, so the
+      # action's build reuses these layers instead of re-pulling (~5 min build).
+      - name: (diag) time YDB base image pulls
+        continue-on-error: true
+        run: |
+          for img in \
+            cr.yandex/crpb3d0up7s6a7iuofo9/ydb-appteam-ci/local-ydb:stable-25-3 \
+            cr.yandex/crpb3d0up7s6a7iuofo9/ydb-appteam-ci/debian:bookworm-slim; do
+            s=$(date +%s)
+            if docker pull "$img" >/dev/null 2>&1; then
+              e=$(( $(date +%s) - s ))
+              bytes=$(docker image inspect "$img" --format '{{.Size}}' 2>/dev/null || echo 0)
+              echo "PULLED  $img  in ${e}s  size=$(( bytes / 1024 / 1024 ))MB"
+            else
+              echo "FAILED  $img  (auth/network) after $(( $(date +%s) - s ))s"
+            fi
+          done
+
       - name: Run SLO Tests
         uses: ydb-platform/ydb-slo-action/init@v2
         timeout-minutes: 30

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -36,9 +36,11 @@ jobs:
           - name: sync-topic
             command: "--write-rps 200 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
+            thresholds_yaml_path: sdk-current/tests/slo/thresholds-topic.yaml
           - name: async-topic
             command: "--write-rps 200 --write-threads 8 --read-threads 8"
             metrics_yaml_path: sdk-current/tests/slo/metrics-topic.yaml
+            thresholds_yaml_path: sdk-current/tests/slo/thresholds-topic.yaml
 
     concurrency:
       group: slo-${{ github.ref }}-${{ matrix.sdk.name }}
@@ -143,3 +145,7 @@ jobs:
           # Custom metrics (e.g. topic e2e latency / loss) merged on top of the
           # action defaults; empty for workloads that don't set it.
           metrics_yaml_path: ${{ matrix.sdk.metrics_yaml_path }}
+          # Per-scenario threshold overrides (topics make read_latency neutral).
+          # Ignored by action versions without ydb-slo-action#57; self-activates
+          # once per-scenario thresholds land in the consumed tag.
+          thresholds_yaml_path: ${{ matrix.sdk.thresholds_yaml_path }}

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -11,7 +11,14 @@ permissions:
 
 jobs:
   ydb-slo-action:
-    if: contains(github.event.pull_request.labels.*.name, 'SLO')
+    # On `labeled` events run only when the `SLO` label itself was just added —
+    # otherwise unrelated label changes (e.g. the AI-review bot toggling
+    # `ai_review_in_process` / `ai_reviewed`) would spawn a fresh run that
+    # cancels the in-progress one via `cancel-in-progress`. For the other
+    # trigger types keep gating on the `SLO` label being present.
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'SLO') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'SLO'))
 
     name: Run YDB SLO Tests
     runs-on: "large-runner-python-sdk"

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -24,6 +24,8 @@ jobs:
             command: "--read-rps 1000 --write-rps 100"
           - name: sync-query
             command: "--read-rps 1000 --write-rps 100"
+          - name: async-query
+            command: "--read-rps 1000 --write-rps 100"
 
     concurrency:
       group: slo-${{ github.ref }}-${{ matrix.sdk.name }}

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -10,10 +10,21 @@ There are two workload types:
 - **Table SLO** - tests table operations (read/write)
 - **Topic SLO** - tests topic operations (publish/consume)
 
-### Implementations:
+### Implementations / labels:
 
-- `sync`
-- `async` (now unimplemented)
+The workload is selected by a single label (`WORKLOAD_NAME` env var, also the
+`sdk.name` matrix value in `.github/workflows/slo.yml`). The sync/async
+execution mode is derived from the label itself — an `async-*` label runs the
+async (`ydb.aio`) path:
+
+| Label          | Service       | Mode  |
+|----------------|---------------|-------|
+| `sync-table`   | Table service | sync  |
+| `sync-query`   | Query service | sync  |
+| `async-query`  | Query service | async |
+| `topic`        | Topic service | sync  |
+
+> The `--async` CLI flag is kept as a manual override for `*-run` commands.
 
 ### Usage:
 

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -279,7 +279,7 @@ Each message carries `writer_id:seqno:write_ts_ns:` followed by padding to the c
 Metrics are collected for both table operations (`read`, `write`) and topic operations (`read`, `write`).
 
 Topic workloads additionally emit (surfaced through `tests/slo/metrics-topic.yaml`, merged into the action metrics via `metrics_yaml_path`):
-- `topic_e2e_latency_p50_ms` / `_p99_ms` — write → read latency of a delivered message (the meaningful topic latency; the generic `read_latency` mostly reflects `receive_message` wait time, not read cost)
+- `topic_e2e_latency_p50_ms` / `_p99_ms` — write → read latency of a delivered message (the meaningful topic latency; the generic `read_latency` mostly reflects `receive_message` wait time, not read cost, so it is kept **informational** for topics via `tests/slo/thresholds-topic.yaml` — `direction: neutral` — while `write_latency` stays gated)
 - `topic_delivered_rps` — unique messages read back per second
 - `topic_lost_errors` — messages detected as lost (must stay 0)
 - `topic_duplicates` — redelivered messages (informational)

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -22,9 +22,11 @@ async (`ydb.aio`) path:
 | `sync-table`   | Table service | sync  |
 | `sync-query`   | Query service | sync  |
 | `async-query`  | Query service | async |
-| `topic`        | Topic service | sync  |
+| `sync-topic`   | Topic service | sync  |
+| `async-topic`  | Topic service | async |
 
 > The `--async` CLI flag is kept as a manual override for `*-run` commands.
+> The bare `topic` label is still accepted as an alias for `sync-topic`.
 
 ### Usage:
 
@@ -257,16 +259,15 @@ Table have these fields:
 Primary key: `("object_hash", "object_id")`
 
 ### Topic workload
-When running `topic-run` command, the program creates three jobs: `readJob`, `writeJob`, `metricsJob`.
+When running `topic-run` (`sync-topic` / `async-topic`), the program creates `readJob`, `writeJob` and `metricsJob`, and additionally **validates end-to-end delivery and per-producer ordering** under chaos.
 
-- `readJob`    reads messages from topic using TopicReader and commits offsets
-- `writeJob`   generates and publishes messages to topic using TopicWriter
-- `metricsJob` periodically sends metrics to Prometheus
+- `writeJob` — each writer is pinned to a partition (`partition_id = i % partitions`) with a stable, ref-scoped `producer_id`, and publishes with `write_with_ack`. The seqno advances only on a successful ack (a failed write leaves no gap).
+- `readJob` — reads with a consumer, commits offsets, and demultiplexes messages by `writer_id`, tracking the next expected seqno per producer (shared across readers, since a partition can move between them on rebalance):
+  - a **forward gap** (a seqno past the expected one) is counted as **lost** — partition order is server-guaranteed, so a gap is real loss (fails the run via the `*_error*` threshold);
+  - a **backward** seqno (already seen) is a **duplicate** — reconnect redelivery; with producer-id dedup it should stay near zero (informational);
+  - **end-to-end latency** is `read_ts − write_ts` for the first delivery of each message (writer and reader share the process, so the timestamps are comparable).
 
-Messages contain:
-- Sequential message ID
-- Thread identifier
-- Configurable payload size (padded with 'x' characters)
+Each message carries `writer_id:seqno:write_ts_ns:` followed by padding to the configured size. Topics are scoped per ref so the current and baseline containers (same cluster, run in parallel) don't share a topic.
 
 ## Collected metrics
 - `oks`      - amount of OK requests
@@ -276,6 +277,12 @@ Messages contain:
 - `attempts` - summary of amount for request
 
 Metrics are collected for both table operations (`read`, `write`) and topic operations (`read`, `write`).
+
+Topic workloads additionally emit (surfaced through `tests/slo/metrics-topic.yaml`, merged into the action metrics via `metrics_yaml_path`):
+- `topic_e2e_latency_p50_ms` / `_p99_ms` — write → read latency of a delivered message (the meaningful topic latency; the generic `read_latency` mostly reflects `receive_message` wait time, not read cost)
+- `topic_delivered_rps` — unique messages read back per second
+- `topic_lost_errors` — messages detected as lost (must stay 0)
+- `topic_duplicates` — redelivered messages (informational)
 
 > Note: with Prometheus OTLP receiver (no Pushgateway) counters/histograms are cumulative and cannot be reset to `0`.
 > If you need clean separation between runs, use distinct `REF`/`WORKLOAD` (and/or `SLO_INSTANCE_ID`) so each run writes into separate time series.

--- a/tests/slo/docker-entrypoint.sh
+++ b/tests/slo/docker-entrypoint.sh
@@ -5,10 +5,13 @@
 # in parallel; both must be able to schema-prepare and then run.
 #
 # Inputs come from the env vars injected by the action:
-#   WORKLOAD_NAME       sync-table | sync-query | topic
+#   WORKLOAD_NAME       sync-table | sync-query | async-query | sync-topic | async-topic
 #   WORKLOAD_DURATION   run duration in seconds
 #   YDB_ENDPOINT        grpc://ydb:2136
 #   YDB_DATABASE        /Root/testdb
+#
+# The sync/async execution mode is derived from the WORKLOAD_NAME label itself
+# (an `async-*` label runs the async path); no extra flag is needed here.
 #
 # Anything passed after the script name is appended to the `*-run` command —
 # this is how tuning flags from `workload_current_command` (e.g. --read-rps)
@@ -17,8 +20,8 @@
 set -e
 
 case "${WORKLOAD_NAME:-sync-query}" in
-    sync-table|sync-query) PREFIX=table ;;
-    topic) PREFIX=topic ;;
+    sync-table|sync-query|async-query|async-table) PREFIX=table ;;
+    topic|sync-topic|async-topic) PREFIX=topic ;;
     *)
         echo "Unknown WORKLOAD_NAME: ${WORKLOAD_NAME}" >&2
         exit 1
@@ -29,12 +32,20 @@ ENDPOINT="${YDB_ENDPOINT:-grpc://localhost:2136}"
 DATABASE="${YDB_DATABASE:-/local}"
 DURATION="${WORKLOAD_DURATION:-600}"
 
+# Topic paths must live under the database; derive one from $DATABASE so the
+# same image works against both local (/local) and CI (/Root/testdb) databases.
+EXTRA_ARGS=""
+if [ "$PREFIX" = "topic" ]; then
+    EXTRA_ARGS="--path ${DATABASE%/}/slo_topic"
+fi
+
 # Schema prep is idempotent at the SDK level for topics; for tables, a parallel
 # baseline container may race and fail with "already exists" — tolerate it.
-python ./tests/slo/src "${PREFIX}-create" "$ENDPOINT" "$DATABASE" \
+python ./tests/slo/src "${PREFIX}-create" "$ENDPOINT" "$DATABASE" $EXTRA_ARGS \
     || echo "WARN: ${PREFIX}-create exited non-zero (treated as already-prepared)" >&2
 
 exec python ./tests/slo/src \
     "${PREFIX}-run" "$ENDPOINT" "$DATABASE" \
     --time "$DURATION" \
+    $EXTRA_ARGS \
     "$@"

--- a/tests/slo/docker-entrypoint.sh
+++ b/tests/slo/docker-entrypoint.sh
@@ -20,7 +20,7 @@
 set -e
 
 case "${WORKLOAD_NAME:-sync-query}" in
-    sync-table|sync-query|async-query|async-table) PREFIX=table ;;
+    sync-table|sync-query|async-query) PREFIX=table ;;
     topic|sync-topic|async-topic) PREFIX=topic ;;
     *)
         echo "Unknown WORKLOAD_NAME: ${WORKLOAD_NAME}" >&2

--- a/tests/slo/docker-entrypoint.sh
+++ b/tests/slo/docker-entrypoint.sh
@@ -34,9 +34,14 @@ DURATION="${WORKLOAD_DURATION:-600}"
 
 # Topic paths must live under the database; derive one from $DATABASE so the
 # same image works against both local (/local) and CI (/Root/testdb) databases.
+# Scope the topic by ref so the current and baseline containers (same cluster,
+# run in parallel) don't share a topic — otherwise their readers/producers would
+# cross-contaminate delivery/ordering validation.
 EXTRA_ARGS=""
 if [ "$PREFIX" = "topic" ]; then
-    EXTRA_ARGS="--path ${DATABASE%/}/slo_topic"
+    REF_RAW="${WORKLOAD_REF:-${REF:-main}}"
+    SAFE_REF=$(printf '%s' "$REF_RAW" | tr -c 'a-zA-Z0-9_' '_')
+    EXTRA_ARGS="--path ${DATABASE%/}/slo_topic_${SAFE_REF}"
 fi
 
 # Schema prep is idempotent at the SDK level for topics; for tables, a parallel

--- a/tests/slo/metrics-topic.yaml
+++ b/tests/slo/metrics-topic.yaml
@@ -1,0 +1,51 @@
+# Custom topic-workload metrics, merged on top of the action's default
+# deploy/metrics.yaml (see ydb-slo-action shared/metrics.ts mergeMetricConfigs).
+# Passed to the action via `metrics_yaml_path` for topic workloads only.
+#
+# Metric names are chosen to match the default threshold patterns
+# (deploy/thresholds.yaml):
+#   *_latency_*  -> lower_is_better
+#   *_rps        -> higher_is_better
+#   *_error*     -> warning_max 0.1 / critical_max 1.0  (fails the run if > 0)
+
+metrics:
+  - name: topic_e2e_latency_p50_ms
+    unit: ms
+    query: |
+      1000 * max by(ref) (
+        sdk_topic_e2e_latency_p50_seconds
+      )
+
+  - name: topic_e2e_latency_p99_ms
+    unit: ms
+    query: |
+      1000 * max by(ref) (
+        sdk_topic_e2e_latency_p99_seconds
+      )
+
+  - name: topic_delivered_rps
+    unit: msgs/s
+    query: |
+      sum by(ref) (
+        rate(sdk_topic_messages_delivered_total[5s])
+      )
+
+  # Lost messages must stay at zero even under chaos (at-least-once delivery).
+  # Named *_error* so the default threshold fails the run on any loss.
+  - name: topic_lost_errors
+    unit: msgs
+    query: |
+      sum by(ref) (
+        increase(sdk_topic_messages_lost_total[5s])
+      )
+    round: 1
+
+  # Duplicates are informational: reconnect redelivery can produce them; with
+  # producer-id dedup they should stay near zero.
+  - name: topic_duplicates
+    unit: msgs
+    query: |
+      sum by(ref) (
+        increase(sdk_topic_messages_duplicated_total[5s])
+      )
+    round: 1

--- a/tests/slo/src/core/metrics.py
+++ b/tests/slo/src/core/metrics.py
@@ -68,6 +68,23 @@ class BaseMetrics(ABC):
         finally:
             self.stop(labels, start_ts, error=error)
 
+    # --- Topic workload extensions (no-ops unless overridden) ---
+    def record_e2e(self, seconds: float) -> None:
+        """Record an end-to-end (write -> read) message latency, in seconds."""
+        return None
+
+    def inc_delivered(self, n: int = 1) -> None:
+        """Count messages successfully read back."""
+        return None
+
+    def inc_lost(self, n: int = 1) -> None:
+        """Count messages detected as lost (a forward gap in a producer's seqno)."""
+        return None
+
+    def inc_duplicated(self, n: int = 1) -> None:
+        """Count messages detected as duplicates (redelivery of an already-seen seqno)."""
+        return None
+
 
 class DummyMetrics(BaseMetrics):
     def start(self, labels) -> float:
@@ -164,8 +181,31 @@ class OtlpMetrics(BaseMetrics):
             for name, _ in self._PERCENTILES
         }
 
+        # Topic-workload metrics: end-to-end (write -> read) latency + delivery counters.
+        self._topic_e2e_gauges = {
+            name: self._meter.create_gauge(
+                name=f"sdk.topic.e2e.latency.{name}.seconds",
+                unit="s",
+                description=f"Topic end-to-end latency {name} computed over the last push window.",
+            )
+            for name, _ in self._PERCENTILES
+        }
+        self._topic_delivered = self._meter.create_counter(
+            name="sdk.topic.messages.delivered.total",
+            description="Total number of messages successfully read back from the topic.",
+        )
+        self._topic_lost = self._meter.create_counter(
+            name="sdk.topic.messages.lost.total",
+            description="Total number of messages detected as lost (forward gap in a producer's seqno).",
+        )
+        self._topic_duplicated = self._meter.create_counter(
+            name="sdk.topic.messages.duplicated.total",
+            description="Total number of messages detected as duplicates (redelivered seqno).",
+        )
+
         self._lock = threading.Lock()
         self._hdr: dict = {}
+        self._e2e_hdr = self._HdrHistogram(self._HDR_MIN_US, self._HDR_MAX_US, self._HDR_SIG_FIGS)
 
     def _get_hdr(self, op_type: str, op_status: str):
         key = (op_type, op_status)
@@ -223,13 +263,35 @@ class OtlpMetrics(BaseMetrics):
                     self._latency_gauges[name].set(value_s, attributes=attrs)
             for hist in self._hdr.values():
                 hist.reset()
+
+            if self._e2e_hdr.get_total_count() > 0:
+                attrs = {"ref": REF}
+                for name, percentile in self._PERCENTILES:
+                    value_s = self._e2e_hdr.get_value_at_percentile(percentile) / 1_000_000
+                    self._topic_e2e_gauges[name].set(value_s, attributes=attrs)
+                self._e2e_hdr.reset()
         self._provider.force_flush()
 
     def reset(self) -> None:
         with self._lock:
             for hist in self._hdr.values():
                 hist.reset()
+            self._e2e_hdr.reset()
         self._provider.force_flush()
+
+    def record_e2e(self, seconds: float) -> None:
+        duration_us = min(max(int(seconds * 1_000_000), self._HDR_MIN_US), self._HDR_MAX_US)
+        with self._lock:
+            self._e2e_hdr.record_value(duration_us)
+
+    def inc_delivered(self, n: int = 1) -> None:
+        self._topic_delivered.add(int(n), attributes={"ref": REF})
+
+    def inc_lost(self, n: int = 1) -> None:
+        self._topic_lost.add(int(n), attributes={"ref": REF})
+
+    def inc_duplicated(self, n: int = 1) -> None:
+        self._topic_duplicated.add(int(n), attributes={"ref": REF})
 
 
 def _resolve_metrics_endpoint(cli_endpoint: Optional[str]) -> str:

--- a/tests/slo/src/jobs/async_table_jobs.py
+++ b/tests/slo/src/jobs/async_table_jobs.py
@@ -1,0 +1,144 @@
+import asyncio
+import logging
+import time
+from random import randint
+
+# `aiolimiter` is a runtime dependency (see `tests/slo/requirements.txt`).
+from aiolimiter import AsyncLimiter  # pyright: ignore[reportMissingImports]
+from core.generator import RowGenerator
+from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
+
+import ydb
+import ydb.aio
+
+from .base import AsyncBaseJobManager
+from .table_jobs import READ_QUERY_TEMPLATE, WRITE_QUERY_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncTableJobManager(AsyncBaseJobManager):
+    def __init__(self, driver, args, metrics, table_name, max_id):
+        super().__init__(driver, args, metrics)
+        # Keep async driver separately to avoid type-incompatible override of BaseJobManager.driver
+        self.aio_driver = driver
+        self.table_name = table_name
+        self.max_id = max_id
+
+        from core.metrics import WORKLOAD
+
+        self.workload_type = WORKLOAD
+
+    async def run_tests(self):
+        if self.workload_type != "async-query":
+            raise ValueError(f"Unsupported async workload type: {self.workload_type}")
+
+        tasks = [
+            *self._run_query_read_jobs(),
+            *self._run_query_write_jobs(),
+            *self._run_metric_job(),
+        ]
+        await asyncio.gather(*tasks)
+
+    def _run_query_read_jobs(self):
+        logger.info("Start async query read jobs")
+
+        read_query = READ_QUERY_TEMPLATE.format(self.table_name)
+        read_limiter = AsyncLimiter(max_rate=max(1, int(self.args.read_rps)), time_period=1)
+
+        tasks = []
+        for i in range(self.args.read_threads):
+            tasks.append(
+                asyncio.create_task(
+                    self._run_query_reads(read_query, read_limiter),
+                    name=f"slo_async_query_read_{i}",
+                )
+            )
+        return tasks
+
+    def _run_query_write_jobs(self):
+        logger.info("Start async query write jobs")
+
+        write_query = WRITE_QUERY_TEMPLATE.format(self.table_name)
+        write_limiter = AsyncLimiter(max_rate=max(1, int(self.args.write_rps)), time_period=1)
+
+        tasks = []
+        for i in range(self.args.write_threads):
+            tasks.append(
+                asyncio.create_task(
+                    self._run_query_writes(write_query, write_limiter),
+                    name=f"slo_async_query_write_{i}",
+                )
+            )
+        return tasks
+
+    async def _run_query_reads(self, query, limiter):
+        start_time = time.time()
+        logger.info("Start async query read workload")
+
+        request_settings = ydb.BaseRequestSettings().with_timeout(self.args.read_timeout / 1000)
+        retry_setting = ydb.RetrySettings(
+            idempotent=True,
+            max_session_acquire_timeout=self.args.read_timeout / 1000,
+        )
+
+        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
+            while time.time() - start_time < self.args.time:
+                params = {"$object_id": (randint(1, self.max_id), ydb.PrimitiveType.Uint64)}
+
+                async with limiter:
+                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_READ,))
+
+        logger.info("Stop async query read workload")
+
+    async def _run_query_writes(self, query, limiter):
+        start_time = time.time()
+        logger.info("Start async query write workload")
+
+        request_settings = ydb.BaseRequestSettings().with_timeout(self.args.write_timeout / 1000)
+        retry_setting = ydb.RetrySettings(
+            idempotent=True,
+            max_session_acquire_timeout=self.args.write_timeout / 1000,
+        )
+
+        row_generator = RowGenerator(self.max_id)
+
+        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
+            while time.time() - start_time < self.args.time:
+                row = row_generator.get()
+                params = {
+                    "$object_id": (row.object_id, ydb.PrimitiveType.Uint64),
+                    "$payload_str": (row.payload_str, ydb.PrimitiveType.Utf8),
+                    "$payload_double": (row.payload_double, ydb.PrimitiveType.Double),
+                    "$payload_timestamp": (row.payload_timestamp, ydb.PrimitiveType.Timestamp),
+                }
+
+                async with limiter:
+                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_WRITE,))
+
+        logger.info("Stop async query write workload")
+
+    async def _execute_query(self, pool, query, params, request_settings, retry_setting, labels):
+        attempt = 0
+        error = None
+
+        async def callee(session):
+            nonlocal attempt
+            attempt += 1
+
+            result_stream = await session.execute(query, parameters=params, settings=request_settings)
+            async for _ in result_stream:
+                pass
+
+        ts = self.metrics.start(labels)
+
+        try:
+            await pool.retry_operation_async(callee, retry_setting)
+        except ydb.Error as err:
+            error = err
+            logger.exception("[labels: %s] Cannot retry error:", labels)
+        except BaseException as err:
+            error = err
+            logger.exception("[labels: %s] Unexpected error:", labels)
+
+        self.metrics.stop(labels, ts, attempts=attempt, error=error)

--- a/tests/slo/src/jobs/async_table_jobs.py
+++ b/tests/slo/src/jobs/async_table_jobs.py
@@ -3,6 +3,8 @@ import logging
 import time
 from random import randint
 
+# `aiolimiter` is a runtime dependency (see `tests/slo/requirements.txt`).
+from aiolimiter import AsyncLimiter  # pyright: ignore[reportMissingImports]
 from core.generator import RowGenerator
 from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
 
@@ -13,11 +15,6 @@ from .base import AsyncBaseJobManager
 from .table_jobs import READ_QUERY_TEMPLATE, WRITE_QUERY_TEMPLATE
 
 logger = logging.getLogger(__name__)
-
-# Upper bound on concurrently in-flight requests per operation (open-loop
-# backpressure). Steady-state in-flight self-regulates to rps * latency
-# (~16 for 1000 rps @ ~16 ms); the cap only engages if latency spikes (chaos).
-MAX_INFLIGHT = 256
 
 
 class AsyncTableJobManager(AsyncBaseJobManager):
@@ -37,41 +34,67 @@ class AsyncTableJobManager(AsyncBaseJobManager):
             raise ValueError(f"Unsupported async workload type: {self.workload_type}")
 
         tasks = [
-            asyncio.create_task(self._run_reads(), name="slo_async_query_read"),
-            asyncio.create_task(self._run_writes(), name="slo_async_query_write"),
+            *self._run_query_read_jobs(),
+            *self._run_query_write_jobs(),
             *self._run_metric_job(),
         ]
         await asyncio.gather(*tasks)
 
-    async def _run_reads(self):
-        # read_threads is kept as an on/off gate; concurrency is driven open-loop.
-        read_rps = int(getattr(self.args, "read_rps", 0))
-        if int(getattr(self.args, "read_threads", 0)) <= 0 or read_rps <= 0:
-            return
+    def _run_query_read_jobs(self):
+        logger.info("Start async query read jobs")
 
+        read_query = READ_QUERY_TEMPLATE.format(self.table_name)
+        read_limiter = AsyncLimiter(max_rate=max(1, int(self.args.read_rps)), time_period=1)
+
+        tasks = []
+        for i in range(self.args.read_threads):
+            tasks.append(
+                asyncio.create_task(
+                    self._run_query_reads(read_query, read_limiter),
+                    name=f"slo_async_query_read_{i}",
+                )
+            )
+        return tasks
+
+    def _run_query_write_jobs(self):
+        logger.info("Start async query write jobs")
+
+        write_query = WRITE_QUERY_TEMPLATE.format(self.table_name)
+        write_limiter = AsyncLimiter(max_rate=max(1, int(self.args.write_rps)), time_period=1)
+
+        tasks = []
+        for i in range(self.args.write_threads):
+            tasks.append(
+                asyncio.create_task(
+                    self._run_query_writes(write_query, write_limiter),
+                    name=f"slo_async_query_write_{i}",
+                )
+            )
+        return tasks
+
+    async def _run_query_reads(self, query, limiter):
+        start_time = time.time()
         logger.info("Start async query read workload")
-        query = READ_QUERY_TEMPLATE.format(self.table_name)
+
         request_settings = ydb.BaseRequestSettings().with_timeout(self.args.read_timeout / 1000)
         retry_setting = ydb.RetrySettings(
             idempotent=True,
             max_session_acquire_timeout=self.args.read_timeout / 1000,
         )
 
-        def make_params():
-            return {"$object_id": (randint(1, self.max_id), ydb.PrimitiveType.Uint64)}
+        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
+            while time.time() - start_time < self.args.time:
+                params = {"$object_id": (randint(1, self.max_id), ydb.PrimitiveType.Uint64)}
 
-        async with ydb.aio.QuerySessionPool(self.aio_driver, size=MAX_INFLIGHT) as pool:
-            await self._generate(read_rps, pool, query, make_params, request_settings, retry_setting, (OP_TYPE_READ,))
+                async with limiter:
+                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_READ,))
 
         logger.info("Stop async query read workload")
 
-    async def _run_writes(self):
-        write_rps = int(getattr(self.args, "write_rps", 0))
-        if int(getattr(self.args, "write_threads", 0)) <= 0 or write_rps <= 0:
-            return
-
+    async def _run_query_writes(self, query, limiter):
+        start_time = time.time()
         logger.info("Start async query write workload")
-        query = WRITE_QUERY_TEMPLATE.format(self.table_name)
+
         request_settings = ydb.BaseRequestSettings().with_timeout(self.args.write_timeout / 1000)
         retry_setting = ydb.RetrySettings(
             idempotent=True,
@@ -80,52 +103,20 @@ class AsyncTableJobManager(AsyncBaseJobManager):
 
         row_generator = RowGenerator(self.max_id)
 
-        def make_params():
-            row = row_generator.get()
-            return {
-                "$object_id": (row.object_id, ydb.PrimitiveType.Uint64),
-                "$payload_str": (row.payload_str, ydb.PrimitiveType.Utf8),
-                "$payload_double": (row.payload_double, ydb.PrimitiveType.Double),
-                "$payload_timestamp": (row.payload_timestamp, ydb.PrimitiveType.Timestamp),
-            }
+        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
+            while time.time() - start_time < self.args.time:
+                row = row_generator.get()
+                params = {
+                    "$object_id": (row.object_id, ydb.PrimitiveType.Uint64),
+                    "$payload_str": (row.payload_str, ydb.PrimitiveType.Utf8),
+                    "$payload_double": (row.payload_double, ydb.PrimitiveType.Double),
+                    "$payload_timestamp": (row.payload_timestamp, ydb.PrimitiveType.Timestamp),
+                }
 
-        async with ydb.aio.QuerySessionPool(self.aio_driver, size=MAX_INFLIGHT) as pool:
-            await self._generate(write_rps, pool, query, make_params, request_settings, retry_setting, (OP_TYPE_WRITE,))
+                async with limiter:
+                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_WRITE,))
 
         logger.info("Stop async query write workload")
-
-    async def _generate(self, rps, pool, query, make_params, request_settings, retry_setting, labels):
-        """Open-loop request generator with even pacing.
-
-        Submissions are spaced evenly at 1/rps; each request runs as its own task,
-        so achieved throughput holds at the target regardless of per-request
-        latency. A semaphore bounds in-flight requests (backpressure); if the DB
-        stalls, submission slows down instead of bursting to catch up.
-        """
-        interval = 1.0 / rps
-        sem = asyncio.Semaphore(MAX_INFLIGHT)
-        deadline = time.time() + self.args.time
-        next_ts = time.monotonic()
-        tasks = set()
-
-        async def one_request():
-            try:
-                await self._execute_query(pool, query, make_params(), request_settings, retry_setting, labels)
-            finally:
-                sem.release()
-
-        while time.time() < deadline:
-            await sem.acquire()  # backpressure: block once MAX_INFLIGHT are in flight
-            delay = next_ts - time.monotonic()
-            if delay > 0:
-                await asyncio.sleep(delay)
-            next_ts = max(next_ts + interval, time.monotonic())  # even pacing, no burst catch-up
-            task = asyncio.create_task(one_request())
-            tasks.add(task)
-            task.add_done_callback(tasks.discard)
-
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _execute_query(self, pool, query, params, request_settings, retry_setting, labels):
         attempt = 0

--- a/tests/slo/src/jobs/async_table_jobs.py
+++ b/tests/slo/src/jobs/async_table_jobs.py
@@ -3,8 +3,6 @@ import logging
 import time
 from random import randint
 
-# `aiolimiter` is a runtime dependency (see `tests/slo/requirements.txt`).
-from aiolimiter import AsyncLimiter  # pyright: ignore[reportMissingImports]
 from core.generator import RowGenerator
 from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
 
@@ -15,6 +13,11 @@ from .base import AsyncBaseJobManager
 from .table_jobs import READ_QUERY_TEMPLATE, WRITE_QUERY_TEMPLATE
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on concurrently in-flight requests per operation (open-loop
+# backpressure). Steady-state in-flight self-regulates to rps * latency
+# (~16 for 1000 rps @ ~16 ms); the cap only engages if latency spikes (chaos).
+MAX_INFLIGHT = 256
 
 
 class AsyncTableJobManager(AsyncBaseJobManager):
@@ -34,67 +37,41 @@ class AsyncTableJobManager(AsyncBaseJobManager):
             raise ValueError(f"Unsupported async workload type: {self.workload_type}")
 
         tasks = [
-            *self._run_query_read_jobs(),
-            *self._run_query_write_jobs(),
+            asyncio.create_task(self._run_reads(), name="slo_async_query_read"),
+            asyncio.create_task(self._run_writes(), name="slo_async_query_write"),
             *self._run_metric_job(),
         ]
         await asyncio.gather(*tasks)
 
-    def _run_query_read_jobs(self):
-        logger.info("Start async query read jobs")
+    async def _run_reads(self):
+        # read_threads is kept as an on/off gate; concurrency is driven open-loop.
+        read_rps = int(getattr(self.args, "read_rps", 0))
+        if int(getattr(self.args, "read_threads", 0)) <= 0 or read_rps <= 0:
+            return
 
-        read_query = READ_QUERY_TEMPLATE.format(self.table_name)
-        read_limiter = AsyncLimiter(max_rate=max(1, int(self.args.read_rps)), time_period=1)
-
-        tasks = []
-        for i in range(self.args.read_threads):
-            tasks.append(
-                asyncio.create_task(
-                    self._run_query_reads(read_query, read_limiter),
-                    name=f"slo_async_query_read_{i}",
-                )
-            )
-        return tasks
-
-    def _run_query_write_jobs(self):
-        logger.info("Start async query write jobs")
-
-        write_query = WRITE_QUERY_TEMPLATE.format(self.table_name)
-        write_limiter = AsyncLimiter(max_rate=max(1, int(self.args.write_rps)), time_period=1)
-
-        tasks = []
-        for i in range(self.args.write_threads):
-            tasks.append(
-                asyncio.create_task(
-                    self._run_query_writes(write_query, write_limiter),
-                    name=f"slo_async_query_write_{i}",
-                )
-            )
-        return tasks
-
-    async def _run_query_reads(self, query, limiter):
-        start_time = time.time()
         logger.info("Start async query read workload")
-
+        query = READ_QUERY_TEMPLATE.format(self.table_name)
         request_settings = ydb.BaseRequestSettings().with_timeout(self.args.read_timeout / 1000)
         retry_setting = ydb.RetrySettings(
             idempotent=True,
             max_session_acquire_timeout=self.args.read_timeout / 1000,
         )
 
-        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
-            while time.time() - start_time < self.args.time:
-                params = {"$object_id": (randint(1, self.max_id), ydb.PrimitiveType.Uint64)}
+        def make_params():
+            return {"$object_id": (randint(1, self.max_id), ydb.PrimitiveType.Uint64)}
 
-                async with limiter:
-                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_READ,))
+        async with ydb.aio.QuerySessionPool(self.aio_driver, size=MAX_INFLIGHT) as pool:
+            await self._generate(read_rps, pool, query, make_params, request_settings, retry_setting, (OP_TYPE_READ,))
 
         logger.info("Stop async query read workload")
 
-    async def _run_query_writes(self, query, limiter):
-        start_time = time.time()
-        logger.info("Start async query write workload")
+    async def _run_writes(self):
+        write_rps = int(getattr(self.args, "write_rps", 0))
+        if int(getattr(self.args, "write_threads", 0)) <= 0 or write_rps <= 0:
+            return
 
+        logger.info("Start async query write workload")
+        query = WRITE_QUERY_TEMPLATE.format(self.table_name)
         request_settings = ydb.BaseRequestSettings().with_timeout(self.args.write_timeout / 1000)
         retry_setting = ydb.RetrySettings(
             idempotent=True,
@@ -103,20 +80,52 @@ class AsyncTableJobManager(AsyncBaseJobManager):
 
         row_generator = RowGenerator(self.max_id)
 
-        async with ydb.aio.QuerySessionPool(self.aio_driver) as pool:
-            while time.time() - start_time < self.args.time:
-                row = row_generator.get()
-                params = {
-                    "$object_id": (row.object_id, ydb.PrimitiveType.Uint64),
-                    "$payload_str": (row.payload_str, ydb.PrimitiveType.Utf8),
-                    "$payload_double": (row.payload_double, ydb.PrimitiveType.Double),
-                    "$payload_timestamp": (row.payload_timestamp, ydb.PrimitiveType.Timestamp),
-                }
+        def make_params():
+            row = row_generator.get()
+            return {
+                "$object_id": (row.object_id, ydb.PrimitiveType.Uint64),
+                "$payload_str": (row.payload_str, ydb.PrimitiveType.Utf8),
+                "$payload_double": (row.payload_double, ydb.PrimitiveType.Double),
+                "$payload_timestamp": (row.payload_timestamp, ydb.PrimitiveType.Timestamp),
+            }
 
-                async with limiter:
-                    await self._execute_query(pool, query, params, request_settings, retry_setting, (OP_TYPE_WRITE,))
+        async with ydb.aio.QuerySessionPool(self.aio_driver, size=MAX_INFLIGHT) as pool:
+            await self._generate(write_rps, pool, query, make_params, request_settings, retry_setting, (OP_TYPE_WRITE,))
 
         logger.info("Stop async query write workload")
+
+    async def _generate(self, rps, pool, query, make_params, request_settings, retry_setting, labels):
+        """Open-loop request generator with even pacing.
+
+        Submissions are spaced evenly at 1/rps; each request runs as its own task,
+        so achieved throughput holds at the target regardless of per-request
+        latency. A semaphore bounds in-flight requests (backpressure); if the DB
+        stalls, submission slows down instead of bursting to catch up.
+        """
+        interval = 1.0 / rps
+        sem = asyncio.Semaphore(MAX_INFLIGHT)
+        deadline = time.time() + self.args.time
+        next_ts = time.monotonic()
+        tasks = set()
+
+        async def one_request():
+            try:
+                await self._execute_query(pool, query, make_params(), request_settings, retry_setting, labels)
+            finally:
+                sem.release()
+
+        while time.time() < deadline:
+            await sem.acquire()  # backpressure: block once MAX_INFLIGHT are in flight
+            delay = next_ts - time.monotonic()
+            if delay > 0:
+                await asyncio.sleep(delay)
+            next_ts = max(next_ts + interval, time.monotonic())  # even pacing, no burst catch-up
+            task = asyncio.create_task(one_request())
+            tasks.add(task)
+            task.add_done_callback(tasks.discard)
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _execute_query(self, pool, query, params, request_settings, retry_setting, labels):
         attempt = 0

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -42,6 +42,12 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
         # Keep async driver separately to avoid type-incompatible override of BaseJobManager.driver
         self.aio_driver = driver
         self.partitions = max(1, int(getattr(self.args, "partitions_count", 1)))
+        # Next expected seqno per producer (writer_id), SHARED across all readers.
+        # In a consumer group a partition can move between readers on rebalance
+        # (chaos reconnects); per-reader state would then see a false forward gap.
+        # Shared state stays correct on handoff. Safe without a lock: all async
+        # readers run on one event loop and _validate() never awaits.
+        self._expected = {}
 
     async def run_tests(self):
         tasks = [
@@ -85,10 +91,9 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
             partition_id=partition_id,
             codec=ydb.TopicCodec.GZIP,
         ) as writer:
-            seqno = 0
+            seqno = 1
             while time.time() - start_time < self.args.time:
                 async with limiter:
-                    seqno += 1
                     payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
                     message = ydb.TopicWriterMessage(data=payload)
 
@@ -97,6 +102,10 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
                         await writer.write_with_ack(message)
                         self.metrics.stop((OP_TYPE_WRITE,), ts)
                         logger.debug("Write w%s seq%s", writer_id, seqno)
+                        # Advance only on success so a failed write leaves no gap
+                        # for the reader (an ack timeout retries the same seqno ->
+                        # at worst a duplicate, never a false loss).
+                        seqno += 1
                     except Exception as e:
                         self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
                         logger.error("Write error: %s", e)
@@ -106,11 +115,6 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
     async def _run_topic_reads(self, reader_id: int):
         start_time = time.time()
         logger.info("Start async topic reader %s", reader_id)
-
-        # Next expected seqno per producer (writer_id). First sighting seeds it,
-        # so a reader that joins mid-stream (rebalance/restart) never reports a
-        # false loss.
-        expected = {}
 
         async with self.aio_driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
             while time.time() - start_time < self.args.time:
@@ -126,7 +130,7 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
                 if msg is None:
                     continue
 
-                self._validate(msg, expected)
+                self._validate(msg)
 
                 try:
                     await reader.commit_with_ack(msg)
@@ -135,7 +139,7 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
 
         logger.info("Stop async topic reader %s", reader_id)
 
-    def _validate(self, msg, expected: dict) -> None:
+    def _validate(self, msg) -> None:
         self.metrics.inc_delivered()
 
         decoded = decode_payload(msg.data)
@@ -145,15 +149,16 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
 
         self.metrics.record_e2e((time.monotonic_ns() - write_ts_ns) / 1e9)
 
-        exp = expected.get(writer_id)
+        exp = self._expected.get(writer_id)
         if exp is None:
-            expected[writer_id] = seqno + 1
+            # First sighting seeds the sequence — never a false loss at join.
+            self._expected[writer_id] = seqno + 1
         elif seqno == exp:
-            expected[writer_id] = seqno + 1
+            self._expected[writer_id] = seqno + 1
         elif seqno > exp:
             # Partition order is server-guaranteed, so a forward gap is real loss.
             self.metrics.inc_lost(seqno - exp)
-            expected[writer_id] = seqno + 1
+            self._expected[writer_id] = seqno + 1
             logger.warning("Lost w%s: expected %s got %s", writer_id, exp, seqno)
         else:
             # seqno < exp: an already-seen seqno came back (reconnect redelivery).

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -118,7 +118,6 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
                         ts = self.metrics.start((OP_TYPE_READ,))
                         try:
                             msg = await asyncio.wait_for(reader.receive_message(), read_timeout)
-                            self.metrics.stop((OP_TYPE_READ,), ts)
                         except asyncio.TimeoutError as e:
                             # No message within read_timeout: at steady rate this
                             # means the reader is starved (outage/stall), so it is
@@ -131,13 +130,18 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
                             break
 
                         if msg is None:
+                            self.metrics.stop((OP_TYPE_READ,), ts)
                             continue
 
                         self._validate(msg)
 
+                        # The read op spans receive+commit, so a commit failure
+                        # shows up as a read error instead of being only logged.
                         try:
                             await asyncio.wait_for(reader.commit_with_ack(msg), read_timeout)
+                            self.metrics.stop((OP_TYPE_READ,), ts)
                         except Exception as e:
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
                             logger.error("Commit error: %s", e)
             except Exception as e:
                 logger.error("Topic reader %s recreate: %s", reader_id, e)

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -140,26 +140,26 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
         logger.info("Stop async topic reader %s", reader_id)
 
     def _validate(self, msg) -> None:
-        self.metrics.inc_delivered()
-
         decoded = decode_payload(msg.data)
         if decoded is None:
+            self.metrics.inc_delivered()
             return
         writer_id, seqno, write_ts_ns = decoded
 
+        exp = self._expected.get(writer_id)
+        if exp is not None and seqno < exp:
+            # Already-seen seqno came back (reconnect redelivery) — not a fresh
+            # delivery, so it counts as a duplicate and is excluded from delivered
+            # / e2e (its write_ts is old and would inflate the latency).
+            self.metrics.inc_duplicated()
+            return
+
+        # Fresh delivery of `seqno`.
+        self.metrics.inc_delivered()
         self.metrics.record_e2e((time.monotonic_ns() - write_ts_ns) / 1e9)
 
-        exp = self._expected.get(writer_id)
-        if exp is None:
-            # First sighting seeds the sequence — never a false loss at join.
-            self._expected[writer_id] = seqno + 1
-        elif seqno == exp:
-            self._expected[writer_id] = seqno + 1
-        elif seqno > exp:
+        if exp is not None and seqno > exp:
             # Partition order is server-guaranteed, so a forward gap is real loss.
             self.metrics.inc_lost(seqno - exp)
-            self._expected[writer_id] = seqno + 1
             logger.warning("Lost w%s: expected %s got %s", writer_id, exp, seqno)
-        else:
-            # seqno < exp: an already-seen seqno came back (reconnect redelivery).
-            self.metrics.inc_duplicated()
+        self._expected[writer_id] = seqno + 1

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -29,6 +29,12 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
         self._expected = {}
 
     async def run_tests(self):
+        # Emit delivery counters at 0 up front so lost/duplicates show as 0 in the
+        # report even on a clean run (instead of a missing series).
+        self.metrics.inc_delivered(0)
+        self.metrics.inc_lost(0)
+        self.metrics.inc_duplicated(0)
+
         tasks = [
             *self._run_topic_write_jobs(),
             *self._run_topic_read_jobs(),

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -9,12 +9,12 @@ from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
 
 import ydb.aio
 
-from .base import BaseJobManager
+from .base import AsyncBaseJobManager
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncTopicJobManager(BaseJobManager):
+class AsyncTopicJobManager(AsyncBaseJobManager):
     def __init__(self, driver, args, metrics):
         super().__init__(driver, args, metrics)
         # Keep async driver separately to avoid type-incompatible override of BaseJobManager.driver
@@ -118,27 +118,3 @@ class AsyncTopicJobManager(BaseJobManager):
                         logger.error("Read error: %s", e)
 
         logger.info("Stop async topic read workload")
-
-    def _run_metric_job(self):
-        # Metrics are enabled only if an OTLP endpoint is provided (CLI: --otlp-endpoint).
-        if not getattr(self.args, "otlp_endpoint", None):
-            return []
-
-        task = asyncio.create_task(
-            self._async_metric_sender(self.args.time),
-            name="slo_metrics_sender",
-        )
-        return [task]
-
-    async def _async_metric_sender(self, runtime: int):
-        start_time = time.time()
-        logger.info("Start push metrics (async)")
-
-        limiter = AsyncLimiter(max_rate=10**6 // self.args.report_period, time_period=1)
-
-        while time.time() - start_time < runtime:
-            async with limiter:
-                # Call sync metrics.push() in executor to avoid blocking the event loop.
-                await asyncio.get_event_loop().run_in_executor(None, self.metrics.push)
-
-        logger.info("Stop push metrics (async)")

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
 import time
-from typing import Optional
 
 # `aiolimiter` is a runtime dependency (see `tests/slo/requirements.txt`).
 from aiolimiter import AsyncLimiter  # pyright: ignore[reportMissingImports]
-from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
+from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE, REF
 
+import ydb
 import ydb.aio
 
 from .base import AsyncBaseJobManager
@@ -14,107 +14,147 @@ from .base import AsyncBaseJobManager
 logger = logging.getLogger(__name__)
 
 
+def encode_payload(writer_id: int, seqno: int, write_ts_ns: int, size: int) -> bytes:
+    """`writer_id:seqno:write_ts_ns:` header, padded to `size` bytes.
+
+    The write timestamp travels inside the message so the reader (same process)
+    can compute end-to-end latency; writer_id + seqno let it validate per-producer
+    ordering and detect loss/duplicates.
+    """
+    header = f"{writer_id}:{seqno}:{write_ts_ns}:".encode("utf-8")
+    if len(header) < size:
+        header += b"x" * (size - len(header))
+    return header
+
+
+def decode_payload(data: bytes):
+    """Return (writer_id, seqno, write_ts_ns) or None if not our payload."""
+    try:
+        parts = data.split(b":", 3)
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except (ValueError, IndexError):
+        return None
+
+
 class AsyncTopicJobManager(AsyncBaseJobManager):
     def __init__(self, driver, args, metrics):
         super().__init__(driver, args, metrics)
         # Keep async driver separately to avoid type-incompatible override of BaseJobManager.driver
         self.aio_driver = driver
+        self.partitions = max(1, int(getattr(self.args, "partitions_count", 1)))
 
     async def run_tests(self):
         tasks = [
-            *await self._run_topic_write_jobs(),
-            *await self._run_topic_read_jobs(),
+            *self._run_topic_write_jobs(),
+            *self._run_topic_read_jobs(),
             *self._run_metric_job(),
         ]
         await asyncio.gather(*tasks)
 
-    async def _run_topic_write_jobs(self):
+    def _run_topic_write_jobs(self):
         logger.info("Start async topic write jobs")
 
-        tasks = []
-        write_limiter = AsyncLimiter(max_rate=self.args.write_rps, time_period=1)
+        # One shared limiter -> total offered write load is write_rps, evenly
+        # spread across writers/partitions (simple, non-adaptive = reproducible).
+        write_limiter = AsyncLimiter(max_rate=max(1, int(self.args.write_rps)), time_period=1)
 
-        for i in range(self.args.write_threads):
-            task = asyncio.create_task(
-                self._run_topic_writes(write_limiter, i),
-                name=f"slo_topic_write_{i}",
-            )
-            tasks.append(task)
+        return [
+            asyncio.create_task(self._run_topic_writes(i, write_limiter), name=f"slo_topic_write_{i}")
+            for i in range(self.args.write_threads)
+        ]
 
-        return tasks
-
-    async def _run_topic_read_jobs(self):
+    def _run_topic_read_jobs(self):
         logger.info("Start async topic read jobs")
 
-        tasks = []
-        read_limiter = AsyncLimiter(max_rate=self.args.read_rps, time_period=1)
+        return [
+            asyncio.create_task(self._run_topic_reads(i), name=f"slo_topic_read_{i}")
+            for i in range(self.args.read_threads)
+        ]
 
-        for i in range(self.args.read_threads):
-            task = asyncio.create_task(
-                self._run_topic_reads(read_limiter),
-                name=f"slo_topic_read_{i}",
-            )
-            tasks.append(task)
-
-        return tasks
-
-    async def _run_topic_writes(self, limiter: AsyncLimiter, partition_id: Optional[int] = None):
+    async def _run_topic_writes(self, writer_id: int, limiter: AsyncLimiter):
         start_time = time.time()
-        logger.info("Start async topic write workload")
+        partition_id = writer_id % self.partitions
+        # producer_id is stable (seqno continues across reconnects) and ref-scoped
+        # (current/baseline share the cluster) so server-side dedup works per writer.
+        producer_id = f"{REF}-p{writer_id}"
+        logger.info("Start async topic writer %s (partition %s, producer %s)", writer_id, partition_id, producer_id)
 
         async with self.aio_driver.topic_client.writer(
             self.args.path,
-            codec=getattr(ydb, "PublicCodec", ydb.TopicCodec).GZIP,
+            producer_id=producer_id,
             partition_id=partition_id,
+            codec=ydb.TopicCodec.GZIP,
         ) as writer:
-            logger.info("Async topic writer created")
-
-            message_count = 0
+            seqno = 0
             while time.time() - start_time < self.args.time:
                 async with limiter:
-                    message_count += 1
-
-                    task = asyncio.current_task()
-                    task_name = task.get_name() if task is not None else "unknown_task"
-                    content = f"message_{message_count}_{task_name}".encode("utf-8")
-                    if len(content) < self.args.message_size:
-                        content += b"x" * (self.args.message_size - len(content))
-
-                    message = ydb.TopicWriterMessage(data=content)
+                    seqno += 1
+                    payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
+                    message = ydb.TopicWriterMessage(data=payload)
 
                     ts = self.metrics.start((OP_TYPE_WRITE,))
                     try:
                         await writer.write_with_ack(message)
-                        logger.info("Write message: %s", content)
                         self.metrics.stop((OP_TYPE_WRITE,), ts)
+                        logger.debug("Write w%s seq%s", writer_id, seqno)
                     except Exception as e:
                         self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
                         logger.error("Write error: %s", e)
 
-        logger.info("Stop async topic write workload")
+        logger.info("Stop async topic writer %s", writer_id)
 
-    async def _run_topic_reads(self, limiter: AsyncLimiter):
+    async def _run_topic_reads(self, reader_id: int):
         start_time = time.time()
-        logger.info("Start async topic read workload")
+        logger.info("Start async topic reader %s", reader_id)
 
-        async with self.aio_driver.topic_client.reader(
-            self.args.path,
-            self.args.consumer,
-        ) as reader:
-            logger.info("Async topic reader created")
+        # Next expected seqno per producer (writer_id). First sighting seeds it,
+        # so a reader that joins mid-stream (rebalance/restart) never reports a
+        # false loss.
+        expected = {}
 
+        async with self.aio_driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
             while time.time() - start_time < self.args.time:
-                async with limiter:
-                    ts = self.metrics.start((OP_TYPE_READ,))
-                    try:
-                        msg = await reader.receive_message()
-                        if msg is not None:
-                            logger.info("Read message: %s", msg.data.decode())
-                            await reader.commit_with_ack(msg)
+                ts = self.metrics.start((OP_TYPE_READ,))
+                try:
+                    msg = await reader.receive_message()
+                    self.metrics.stop((OP_TYPE_READ,), ts)
+                except Exception as e:
+                    self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                    logger.error("Read error: %s", e)
+                    continue
 
-                        self.metrics.stop((OP_TYPE_READ,), ts)
-                    except Exception as e:
-                        self.metrics.stop((OP_TYPE_READ,), ts, error=e)
-                        logger.error("Read error: %s", e)
+                if msg is None:
+                    continue
 
-        logger.info("Stop async topic read workload")
+                self._validate(msg, expected)
+
+                try:
+                    await reader.commit_with_ack(msg)
+                except Exception as e:
+                    logger.error("Commit error: %s", e)
+
+        logger.info("Stop async topic reader %s", reader_id)
+
+    def _validate(self, msg, expected: dict) -> None:
+        self.metrics.inc_delivered()
+
+        decoded = decode_payload(msg.data)
+        if decoded is None:
+            return
+        writer_id, seqno, write_ts_ns = decoded
+
+        self.metrics.record_e2e((time.monotonic_ns() - write_ts_ns) / 1e9)
+
+        exp = expected.get(writer_id)
+        if exp is None:
+            expected[writer_id] = seqno + 1
+        elif seqno == exp:
+            expected[writer_id] = seqno + 1
+        elif seqno > exp:
+            # Partition order is server-guaranteed, so a forward gap is real loss.
+            self.metrics.inc_lost(seqno - exp)
+            expected[writer_id] = seqno + 1
+            logger.warning("Lost w%s: expected %s got %s", writer_id, exp, seqno)
+        else:
+            # seqno < exp: an already-seen seqno came back (reconnect redelivery).
+            self.metrics.inc_duplicated()

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -10,30 +10,9 @@ import ydb
 import ydb.aio
 
 from .base import AsyncBaseJobManager
+from .topic_payload import decode_payload, encode_payload
 
 logger = logging.getLogger(__name__)
-
-
-def encode_payload(writer_id: int, seqno: int, write_ts_ns: int, size: int) -> bytes:
-    """`writer_id:seqno:write_ts_ns:` header, padded to `size` bytes.
-
-    The write timestamp travels inside the message so the reader (same process)
-    can compute end-to-end latency; writer_id + seqno let it validate per-producer
-    ordering and detect loss/duplicates.
-    """
-    header = f"{writer_id}:{seqno}:{write_ts_ns}:".encode("utf-8")
-    if len(header) < size:
-        header += b"x" * (size - len(header))
-    return header
-
-
-def decode_payload(data: bytes):
-    """Return (writer_id, seqno, write_ts_ns) or None if not our payload."""
-    try:
-        parts = data.split(b":", 3)
-        return int(parts[0]), int(parts[1]), int(parts[2])
-    except (ValueError, IndexError):
-        return None
 
 
 class AsyncTopicJobManager(AsyncBaseJobManager):

--- a/tests/slo/src/jobs/async_topic_jobs.py
+++ b/tests/slo/src/jobs/async_topic_jobs.py
@@ -68,59 +68,80 @@ class AsyncTopicJobManager(AsyncBaseJobManager):
         # producer_id is stable (seqno continues across reconnects) and ref-scoped
         # (current/baseline share the cluster) so server-side dedup works per writer.
         producer_id = f"{REF}-p{writer_id}"
+        write_timeout = self.args.write_timeout / 1000
         logger.info("Start async topic writer %s (partition %s, producer %s)", writer_id, partition_id, producer_id)
 
-        async with self.aio_driver.topic_client.writer(
-            self.args.path,
-            producer_id=producer_id,
-            partition_id=partition_id,
-            codec=ydb.TopicCodec.GZIP,
-        ) as writer:
-            seqno = 1
-            while time.time() - start_time < self.args.time:
-                async with limiter:
-                    payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
-                    message = ydb.TopicWriterMessage(data=payload)
+        # `seqno` lives across writer recreations so the sequence the reader sees
+        # never resets. The outer loop recreates the writer if it breaks/stalls
+        # (an SDK write can hang under chaos) so the workload never silently hangs.
+        seqno = 1
+        while time.time() - start_time < self.args.time:
+            try:
+                async with self.aio_driver.topic_client.writer(
+                    self.args.path,
+                    producer_id=producer_id,
+                    partition_id=partition_id,
+                    codec=ydb.TopicCodec.RAW,
+                ) as writer:
+                    while time.time() - start_time < self.args.time:
+                        async with limiter:
+                            payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
+                            message = ydb.TopicWriterMessage(data=payload)
 
-                    ts = self.metrics.start((OP_TYPE_WRITE,))
-                    try:
-                        await writer.write_with_ack(message)
-                        self.metrics.stop((OP_TYPE_WRITE,), ts)
-                        logger.debug("Write w%s seq%s", writer_id, seqno)
-                        # Advance only on success so a failed write leaves no gap
-                        # for the reader (an ack timeout retries the same seqno ->
-                        # at worst a duplicate, never a false loss).
-                        seqno += 1
-                    except Exception as e:
-                        self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
-                        logger.error("Write error: %s", e)
+                            ts = self.metrics.start((OP_TYPE_WRITE,))
+                            try:
+                                await asyncio.wait_for(writer.write_with_ack(message), write_timeout)
+                                self.metrics.stop((OP_TYPE_WRITE,), ts)
+                                # Advance only on success -> a failed write leaves
+                                # no gap (a timeout retries the seqno: at worst a
+                                # duplicate, never a false loss).
+                                seqno += 1
+                            except Exception as e:
+                                self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
+                                logger.error("Write error (recreating writer): %s", e)
+                                break  # drop the (possibly wedged) writer and remake it
+            except Exception as e:
+                logger.error("Topic writer %s recreate: %s", writer_id, e)
+                await asyncio.sleep(0.2)
 
         logger.info("Stop async topic writer %s", writer_id)
 
     async def _run_topic_reads(self, reader_id: int):
         start_time = time.time()
+        read_timeout = self.args.read_timeout / 1000
         logger.info("Start async topic reader %s", reader_id)
 
-        async with self.aio_driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
-            while time.time() - start_time < self.args.time:
-                ts = self.metrics.start((OP_TYPE_READ,))
-                try:
-                    msg = await reader.receive_message()
-                    self.metrics.stop((OP_TYPE_READ,), ts)
-                except Exception as e:
-                    self.metrics.stop((OP_TYPE_READ,), ts, error=e)
-                    logger.error("Read error: %s", e)
-                    continue
+        while time.time() - start_time < self.args.time:
+            try:
+                async with self.aio_driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
+                    while time.time() - start_time < self.args.time:
+                        ts = self.metrics.start((OP_TYPE_READ,))
+                        try:
+                            msg = await asyncio.wait_for(reader.receive_message(), read_timeout)
+                            self.metrics.stop((OP_TYPE_READ,), ts)
+                        except asyncio.TimeoutError as e:
+                            # No message within read_timeout: at steady rate this
+                            # means the reader is starved (outage/stall), so it is
+                            # a read failure (visible), not a silent wait.
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                            continue
+                        except Exception as e:
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                            logger.error("Read error (recreating reader): %s", e)
+                            break
 
-                if msg is None:
-                    continue
+                        if msg is None:
+                            continue
 
-                self._validate(msg)
+                        self._validate(msg)
 
-                try:
-                    await reader.commit_with_ack(msg)
-                except Exception as e:
-                    logger.error("Commit error: %s", e)
+                        try:
+                            await asyncio.wait_for(reader.commit_with_ack(msg), read_timeout)
+                        except Exception as e:
+                            logger.error("Commit error: %s", e)
+            except Exception as e:
+                logger.error("Topic reader %s recreate: %s", reader_id, e)
+                await asyncio.sleep(0.2)
 
         logger.info("Stop async topic reader %s", reader_id)
 

--- a/tests/slo/src/jobs/base.py
+++ b/tests/slo/src/jobs/base.py
@@ -108,11 +108,13 @@ class AsyncBaseJobManager(BaseJobManager):
         start_time = time.time()
         logger.info("Start push metrics (async)")
 
-        limiter = AsyncLimiter(max_rate=10**6 // self.args.report_period, time_period=1)
+        # One push per report_period (mirrors the sync SyncRateLimiter); guard 0.
+        report_period_ms = max(1, int(self.args.report_period))
+        limiter = AsyncLimiter(max_rate=1, time_period=report_period_ms / 1000.0)
 
         while time.time() - start_time < runtime:
             async with limiter:
                 # Call sync metrics.push() in executor to avoid blocking the event loop.
-                await asyncio.get_event_loop().run_in_executor(None, self.metrics.push)
+                await asyncio.get_running_loop().run_in_executor(None, self.metrics.push)
 
         logger.info("Stop push metrics (async)")

--- a/tests/slo/src/jobs/base.py
+++ b/tests/slo/src/jobs/base.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 import time
@@ -77,3 +78,41 @@ class BaseJobManager(ABC):
                 self.metrics.push()
 
         logger.info("Stop push metrics")
+
+
+class AsyncBaseJobManager(BaseJobManager):
+    """Base for asyncio-based job managers.
+
+    Overrides the metrics job with an asyncio task so it can be awaited
+    together with the read/write tasks via ``asyncio.gather``.
+    """
+
+    @abstractmethod
+    async def run_tests(self):
+        pass
+
+    def _run_metric_job(self):
+        if not getattr(self.args, "otlp_endpoint", None):
+            return []
+
+        task = asyncio.create_task(
+            self._async_metric_sender(self.args.time),
+            name="slo_metrics_sender",
+        )
+        return [task]
+
+    async def _async_metric_sender(self, runtime):
+        # `aiolimiter` is a runtime dependency (see `tests/slo/requirements.txt`).
+        from aiolimiter import AsyncLimiter  # pyright: ignore[reportMissingImports]
+
+        start_time = time.time()
+        logger.info("Start push metrics (async)")
+
+        limiter = AsyncLimiter(max_rate=10**6 // self.args.report_period, time_period=1)
+
+        while time.time() - start_time < runtime:
+            async with limiter:
+                # Call sync metrics.push() in executor to avoid blocking the event loop.
+                await asyncio.get_event_loop().run_in_executor(None, self.metrics.push)
+
+        logger.info("Stop push metrics (async)")

--- a/tests/slo/src/jobs/topic_jobs.py
+++ b/tests/slo/src/jobs/topic_jobs.py
@@ -23,6 +23,12 @@ class TopicJobManager(BaseJobManager):
         self._expected_lock = threading.Lock()
 
     def run_tests(self):
+        # Emit delivery counters at 0 up front so lost/duplicates show as 0 in the
+        # report even on a clean run (instead of a missing series).
+        self.metrics.inc_delivered(0)
+        self.metrics.inc_lost(0)
+        self.metrics.inc_duplicated(0)
+
         futures = [
             *self._run_topic_write_jobs(),
             *self._run_topic_read_jobs(),

--- a/tests/slo/src/jobs/topic_jobs.py
+++ b/tests/slo/src/jobs/topic_jobs.py
@@ -2,29 +2,40 @@ import logging
 import threading
 import time
 
-from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE
+from core.metrics import OP_TYPE_READ, OP_TYPE_WRITE, REF
 
 import ydb
 
 from .base import BaseJobManager, SyncRateLimiter
+from .topic_payload import decode_payload, encode_payload
 
 logger = logging.getLogger(__name__)
 
 
 class TopicJobManager(BaseJobManager):
+    def __init__(self, driver, args, metrics):
+        super().__init__(driver, args, metrics)
+        self.partitions = max(1, int(getattr(self.args, "partitions_count", 1)))
+        # Next expected seqno per producer (writer_id), shared across reader
+        # threads (a partition can move between readers on rebalance). Guarded by
+        # a lock because sync readers are real threads (unlike the async loop).
+        self._expected = {}
+        self._expected_lock = threading.Lock()
+
     def run_tests(self):
         futures = [
             *self._run_topic_write_jobs(),
             *self._run_topic_read_jobs(),
             *self._run_metric_job(),
         ]
-
         for future in futures:
             future.join()
 
     def _run_topic_write_jobs(self):
         logger.info("Start topic write jobs")
 
+        # One shared limiter -> total offered write load is write_rps, evenly
+        # spread across writers/partitions (simple, non-adaptive = reproducible).
         write_rps = int(getattr(self.args, "write_rps", 0))
         write_limiter = SyncRateLimiter(min_interval_s=0.0 if write_rps <= 0 else 1.0 / write_rps)
 
@@ -33,90 +44,111 @@ class TopicJobManager(BaseJobManager):
             future = threading.Thread(
                 name=f"slo_topic_write_{i}",
                 target=self._run_topic_writes,
-                args=(
-                    write_limiter,
-                    i,
-                ),
+                args=(i, write_limiter),
             )
             future.start()
             futures.append(future)
-
         return futures
 
     def _run_topic_read_jobs(self):
         logger.info("Start topic read jobs")
-
-        read_rps = int(getattr(self.args, "read_rps", 0))
-        read_limiter = SyncRateLimiter(min_interval_s=0.0 if read_rps <= 0 else 1.0 / read_rps)
 
         futures = []
         for i in range(self.args.read_threads):
             future = threading.Thread(
                 name=f"slo_topic_read_{i}",
                 target=self._run_topic_reads,
-                args=(read_limiter,),
+                args=(i,),
             )
             future.start()
             futures.append(future)
-
         return futures
 
-    def _run_topic_writes(self, limiter, partition_id=None):
+    def _run_topic_writes(self, writer_id, limiter):
         start_time = time.time()
-        logger.info("Start topic write workload")
+        partition_id = writer_id % self.partitions
+        producer_id = f"{REF}-p{writer_id}"
+        logger.info("Start topic writer %s (partition %s, producer %s)", writer_id, partition_id, producer_id)
 
         with self.driver.topic_client.writer(
             self.args.path,
-            codec=ydb.TopicCodec.GZIP,
+            producer_id=producer_id,
             partition_id=partition_id,
+            codec=ydb.TopicCodec.GZIP,
         ) as writer:
-            logger.info("Topic writer created")
-
-            message_count = 0
+            seqno = 1
             while time.time() - start_time < self.args.time:
                 with limiter:
-                    message_count += 1
-
-                    content = f"message_{message_count}_{threading.current_thread().name}".encode("utf-8")
-
-                    if len(content) < self.args.message_size:
-                        content += b"x" * (self.args.message_size - len(content))
-
-                    message = ydb.TopicWriterMessage(data=content)
+                    payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
+                    message = ydb.TopicWriterMessage(data=payload)
 
                     ts = self.metrics.start((OP_TYPE_WRITE,))
                     try:
                         writer.write_with_ack(message)
-                        logger.info("Write message: %s", content)
                         self.metrics.stop((OP_TYPE_WRITE,), ts)
+                        logger.debug("Write w%s seq%s", writer_id, seqno)
+                        # Advance only on success so a failed write leaves no gap
+                        # for the reader (an ack timeout retries the same seqno ->
+                        # at worst a duplicate, never a false loss).
+                        seqno += 1
                     except Exception as e:
                         self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
                         logger.error("Write error: %s", e)
 
-        logger.info("Stop topic write workload")
+        logger.info("Stop topic writer %s", writer_id)
 
-    def _run_topic_reads(self, limiter):
+    def _run_topic_reads(self, reader_id):
         start_time = time.time()
-        logger.info("Start topic read workload")
+        logger.info("Start topic reader %s", reader_id)
 
-        with self.driver.topic_client.reader(
-            self.args.path,
-            self.args.consumer,
-        ) as reader:
-            logger.info("Topic reader created")
-
+        with self.driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
             while time.time() - start_time < self.args.time:
-                with limiter:
-                    ts = self.metrics.start((OP_TYPE_READ,))
-                    try:
-                        msg = reader.receive_message()
-                        if msg is not None:
-                            logger.info("Read message: %s", msg.data.decode())
-                            reader.commit_with_ack(msg)
+                ts = self.metrics.start((OP_TYPE_READ,))
+                try:
+                    msg = reader.receive_message()
+                    self.metrics.stop((OP_TYPE_READ,), ts)
+                except Exception as e:
+                    self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                    logger.error("Read error: %s", e)
+                    continue
 
-                        self.metrics.stop((OP_TYPE_READ,), ts)
-                    except Exception as e:
-                        self.metrics.stop((OP_TYPE_READ,), ts, error=e)
-                        logger.error("Read error: %s", e)
+                if msg is None:
+                    continue
 
-        logger.info("Stop topic read workload")
+                self._validate(msg)
+
+                try:
+                    reader.commit_with_ack(msg)
+                except Exception as e:
+                    logger.error("Commit error: %s", e)
+
+        logger.info("Stop topic reader %s", reader_id)
+
+    def _validate(self, msg):
+        decoded = decode_payload(msg.data)
+        if decoded is None:
+            self.metrics.inc_delivered()
+            return
+        writer_id, seqno, write_ts_ns = decoded
+
+        lost_n = 0
+        with self._expected_lock:
+            exp = self._expected.get(writer_id)
+            duplicate = exp is not None and seqno < exp
+            if not duplicate:
+                if exp is not None and seqno > exp:
+                    lost_n = seqno - exp
+                self._expected[writer_id] = seqno + 1
+
+        if duplicate:
+            # Already-seen seqno came back (reconnect redelivery): not a fresh
+            # delivery, excluded from delivered / e2e (old write_ts).
+            self.metrics.inc_duplicated()
+            return
+
+        self.metrics.inc_delivered()
+        self.metrics.record_e2e((time.monotonic_ns() - write_ts_ns) / 1e9)
+        if lost_n:
+            # Partition order is server-guaranteed, so a forward gap is real loss.
+            self.metrics.inc_lost(lost_n)
+            logger.warning("Lost w%s: expected %s got %s", writer_id, exp, seqno)

--- a/tests/slo/src/jobs/topic_jobs.py
+++ b/tests/slo/src/jobs/topic_jobs.py
@@ -124,7 +124,6 @@ class TopicJobManager(BaseJobManager):
                         ts = self.metrics.start((OP_TYPE_READ,))
                         try:
                             msg = reader.receive_message(timeout=read_timeout)
-                            self.metrics.stop((OP_TYPE_READ,), ts)
                         except TimeoutError as e:
                             # No message within read_timeout: at steady rate this
                             # means the reader is starved (outage/stall), so it is
@@ -137,13 +136,18 @@ class TopicJobManager(BaseJobManager):
                             break
 
                         if msg is None:
+                            self.metrics.stop((OP_TYPE_READ,), ts)
                             continue
 
                         self._validate(msg)
 
+                        # The read op spans receive+commit, so a commit failure
+                        # shows up as a read error instead of being only logged.
                         try:
                             reader.commit_with_ack(msg, timeout=read_timeout)
+                            self.metrics.stop((OP_TYPE_READ,), ts)
                         except Exception as e:
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
                             logger.error("Commit error: %s", e)
             except Exception as e:
                 logger.error("Topic reader %s recreate: %s", reader_id, e)

--- a/tests/slo/src/jobs/topic_jobs.py
+++ b/tests/slo/src/jobs/topic_jobs.py
@@ -74,59 +74,80 @@ class TopicJobManager(BaseJobManager):
         start_time = time.time()
         partition_id = writer_id % self.partitions
         producer_id = f"{REF}-p{writer_id}"
+        write_timeout = self.args.write_timeout / 1000
         logger.info("Start topic writer %s (partition %s, producer %s)", writer_id, partition_id, producer_id)
 
-        with self.driver.topic_client.writer(
-            self.args.path,
-            producer_id=producer_id,
-            partition_id=partition_id,
-            codec=ydb.TopicCodec.GZIP,
-        ) as writer:
-            seqno = 1
-            while time.time() - start_time < self.args.time:
-                with limiter:
-                    payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
-                    message = ydb.TopicWriterMessage(data=payload)
+        # `seqno` lives across writer recreations so the sequence the reader sees
+        # never resets. The outer loop recreates the writer if it breaks/stalls so
+        # the workload never silently hangs.
+        seqno = 1
+        while time.time() - start_time < self.args.time:
+            try:
+                with self.driver.topic_client.writer(
+                    self.args.path,
+                    producer_id=producer_id,
+                    partition_id=partition_id,
+                    codec=ydb.TopicCodec.RAW,
+                ) as writer:
+                    while time.time() - start_time < self.args.time:
+                        with limiter:
+                            payload = encode_payload(writer_id, seqno, time.monotonic_ns(), self.args.message_size)
+                            message = ydb.TopicWriterMessage(data=payload)
 
-                    ts = self.metrics.start((OP_TYPE_WRITE,))
-                    try:
-                        writer.write_with_ack(message)
-                        self.metrics.stop((OP_TYPE_WRITE,), ts)
-                        logger.debug("Write w%s seq%s", writer_id, seqno)
-                        # Advance only on success so a failed write leaves no gap
-                        # for the reader (an ack timeout retries the same seqno ->
-                        # at worst a duplicate, never a false loss).
-                        seqno += 1
-                    except Exception as e:
-                        self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
-                        logger.error("Write error: %s", e)
+                            ts = self.metrics.start((OP_TYPE_WRITE,))
+                            try:
+                                writer.write_with_ack(message, timeout=write_timeout)
+                                self.metrics.stop((OP_TYPE_WRITE,), ts)
+                                # Advance only on success -> a failed write leaves
+                                # no gap (a timeout retries the seqno: at worst a
+                                # duplicate, never a false loss).
+                                seqno += 1
+                            except Exception as e:
+                                self.metrics.stop((OP_TYPE_WRITE,), ts, error=e)
+                                logger.error("Write error (recreating writer): %s", e)
+                                break  # drop the (possibly wedged) writer and remake it
+            except Exception as e:
+                logger.error("Topic writer %s recreate: %s", writer_id, e)
+                time.sleep(0.2)
 
         logger.info("Stop topic writer %s", writer_id)
 
     def _run_topic_reads(self, reader_id):
         start_time = time.time()
+        read_timeout = self.args.read_timeout / 1000
         logger.info("Start topic reader %s", reader_id)
 
-        with self.driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
-            while time.time() - start_time < self.args.time:
-                ts = self.metrics.start((OP_TYPE_READ,))
-                try:
-                    msg = reader.receive_message()
-                    self.metrics.stop((OP_TYPE_READ,), ts)
-                except Exception as e:
-                    self.metrics.stop((OP_TYPE_READ,), ts, error=e)
-                    logger.error("Read error: %s", e)
-                    continue
+        while time.time() - start_time < self.args.time:
+            try:
+                with self.driver.topic_client.reader(self.args.path, self.args.consumer) as reader:
+                    while time.time() - start_time < self.args.time:
+                        ts = self.metrics.start((OP_TYPE_READ,))
+                        try:
+                            msg = reader.receive_message(timeout=read_timeout)
+                            self.metrics.stop((OP_TYPE_READ,), ts)
+                        except TimeoutError as e:
+                            # No message within read_timeout: at steady rate this
+                            # means the reader is starved (outage/stall), so it is
+                            # a read failure (visible), not a silent wait.
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                            continue
+                        except Exception as e:
+                            self.metrics.stop((OP_TYPE_READ,), ts, error=e)
+                            logger.error("Read error (recreating reader): %s", e)
+                            break
 
-                if msg is None:
-                    continue
+                        if msg is None:
+                            continue
 
-                self._validate(msg)
+                        self._validate(msg)
 
-                try:
-                    reader.commit_with_ack(msg)
-                except Exception as e:
-                    logger.error("Commit error: %s", e)
+                        try:
+                            reader.commit_with_ack(msg, timeout=read_timeout)
+                        except Exception as e:
+                            logger.error("Commit error: %s", e)
+            except Exception as e:
+                logger.error("Topic reader %s recreate: %s", reader_id, e)
+                time.sleep(0.2)
 
         logger.info("Stop topic reader %s", reader_id)
 

--- a/tests/slo/src/jobs/topic_payload.py
+++ b/tests/slo/src/jobs/topic_payload.py
@@ -1,0 +1,23 @@
+"""Shared topic message payload codec used by the sync and async topic workloads.
+
+The write timestamp travels inside the message so the reader (same process) can
+compute end-to-end latency; writer_id + seqno let it validate per-producer
+ordering and detect loss / duplicates.
+"""
+
+
+def encode_payload(writer_id: int, seqno: int, write_ts_ns: int, size: int) -> bytes:
+    """`writer_id:seqno:write_ts_ns:` header, padded to `size` bytes."""
+    header = f"{writer_id}:{seqno}:{write_ts_ns}:".encode("utf-8")
+    if len(header) < size:
+        header += b"x" * (size - len(header))
+    return header
+
+
+def decode_payload(data: bytes):
+    """Return (writer_id, seqno, write_ts_ns) or None if not our payload."""
+    try:
+        parts = data.split(b":", 3)
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except (ValueError, IndexError):
+        return None

--- a/tests/slo/src/options.py
+++ b/tests/slo/src/options.py
@@ -103,7 +103,7 @@ def make_topic_create_parser(subparsers):
 
     topic_create_parser.add_argument("--path", default="/local/slo_topic", type=str, help="Topic path")
     topic_create_parser.add_argument("--consumer", default="slo_consumer", type=str, help="Topic consumer name")
-    topic_create_parser.add_argument("--partitions-count", default=1, type=int, help="Partition count")
+    topic_create_parser.add_argument("--partitions-count", default=2, type=int, help="Partition count")
 
 
 def make_topic_run_parser(subparsers):
@@ -112,7 +112,7 @@ def make_topic_run_parser(subparsers):
 
     topic_parser.add_argument("--path", default="/local/slo_topic", type=str, help="Topic path")
     topic_parser.add_argument("--consumer", default="slo_consumer", type=str, help="Topic consumer name")
-    topic_parser.add_argument("--partitions-count", default=1, type=int, help="Partition count")
+    topic_parser.add_argument("--partitions-count", default=2, type=int, help="Partition count")
     topic_parser.add_argument("--read-rps", default=100, type=int, help="Topic read request rps")
     topic_parser.add_argument("--read-timeout", default=5000, type=int, help="Topic read timeout [ms]")
     topic_parser.add_argument("--write-rps", default=100, type=int, help="Topic write request rps")

--- a/tests/slo/src/options.py
+++ b/tests/slo/src/options.py
@@ -88,8 +88,8 @@ def make_table_run_parser(subparsers):
     )
     table_run_parser.add_argument("--report-period", default=1000, type=int, help="Prometheus push period in [ms]")
 
-    table_run_parser.add_argument("--read-threads", default=8, type=int, help="Number of threads to use for write")
-    table_run_parser.add_argument("--write-threads", default=4, type=int, help="Number of threads to use for read")
+    table_run_parser.add_argument("--read-threads", default=8, type=int, help="Number of threads to use for read")
+    table_run_parser.add_argument("--write-threads", default=4, type=int, help="Number of threads to use for write")
 
 
 def make_table_cleanup_parser(subparsers):

--- a/tests/slo/src/options.py
+++ b/tests/slo/src/options.py
@@ -103,7 +103,7 @@ def make_topic_create_parser(subparsers):
 
     topic_create_parser.add_argument("--path", default="/local/slo_topic", type=str, help="Topic path")
     topic_create_parser.add_argument("--consumer", default="slo_consumer", type=str, help="Topic consumer name")
-    topic_create_parser.add_argument("--partitions-count", default=2, type=int, help="Partition count")
+    topic_create_parser.add_argument("--partitions-count", default=8, type=int, help="Partition count")
 
 
 def make_topic_run_parser(subparsers):
@@ -112,7 +112,7 @@ def make_topic_run_parser(subparsers):
 
     topic_parser.add_argument("--path", default="/local/slo_topic", type=str, help="Topic path")
     topic_parser.add_argument("--consumer", default="slo_consumer", type=str, help="Topic consumer name")
-    topic_parser.add_argument("--partitions-count", default=2, type=int, help="Partition count")
+    topic_parser.add_argument("--partitions-count", default=8, type=int, help="Partition count")
     topic_parser.add_argument("--read-rps", default=100, type=int, help="Topic read request rps")
     topic_parser.add_argument("--read-timeout", default=5000, type=int, help="Topic read timeout [ms]")
     topic_parser.add_argument("--write-rps", default=100, type=int, help="Topic write request rps")

--- a/tests/slo/src/root_runner.py
+++ b/tests/slo/src/root_runner.py
@@ -4,11 +4,18 @@ import ydb.aio
 import logging
 from typing import Dict
 
+from core.metrics import WORKLOAD
 from runners.topic_runner import TopicRunner
 from runners.table_runner import TableRunner
 from runners.base import BaseRunner
 
 logger = logging.getLogger(__name__)
+
+
+def _is_async_workload(args) -> bool:
+    """Async mode is driven by the workload label (``async-*``); the ``--async``
+    CLI flag is kept as a manual override."""
+    return getattr(args, "async", False) or str(WORKLOAD).startswith("async-")
 
 
 class SLORunner:
@@ -29,8 +36,9 @@ class SLORunner:
 
         runner_instance = self.runners[prefix]()
 
-        # Check if async mode is requested and command is 'run'
-        if getattr(args, "async", False) and command == "run":
+        # Async mode (driven by the workload label, e.g. async-query / async-topic)
+        # only applies to the long-running `run` command; create/cleanup stay sync.
+        if _is_async_workload(args) and command == "run":
             asyncio.run(self._run_async_command(args, runner_instance, command))
         else:
             self._run_sync_command(args, runner_instance, command)

--- a/tests/slo/src/runners/table_runner.py
+++ b/tests/slo/src/runners/table_runner.py
@@ -4,9 +4,11 @@ from os import path
 
 from core.generator import batch_generator
 from core.metrics import create_metrics
+from jobs.async_table_jobs import AsyncTableJobManager
 from jobs.table_jobs import TableJobManager
 
 import ydb
+import ydb.aio
 
 from .base import BaseRunner
 
@@ -107,6 +109,28 @@ class TableRunner(BaseRunner):
         job_manager.run_tests()
 
         self.logger.info("Table SLO tests completed")
+
+        if hasattr(metrics, "reset"):
+            metrics.reset()
+
+    async def run_async(self, args):
+        """Async version of table SLO tests (query service) using ydb.aio.Driver"""
+        assert self.driver is not None, "Driver is not initialized. Call set_driver() before run_async()."
+        metrics = create_metrics(args.otlp_endpoint)
+
+        self.logger.info("Starting async table SLO tests")
+
+        table_name = path.join(args.db, args.table_name)
+
+        async with ydb.aio.QuerySessionPool(self.driver) as pool:
+            result = await pool.execute_with_retries("SELECT MAX(`object_id`) as max_id FROM `{}`".format(table_name))
+        max_id = result[0].rows[0]["max_id"]
+        self.logger.info("Max ID: %s", max_id)
+
+        job_manager = AsyncTableJobManager(self.driver, args, metrics, table_name, max_id)
+        await job_manager.run_tests()
+
+        self.logger.info("Async table SLO tests completed")
 
         if hasattr(metrics, "reset"):
             metrics.reset()

--- a/tests/slo/thresholds-topic.yaml
+++ b/tests/slo/thresholds-topic.yaml
@@ -4,13 +4,20 @@
 # threshold overrides"). On an action version without that feature this file is
 # simply ignored, so wiring it is harmless and self-activates once it lands.
 #
-# Why: for topics the generic `read_latency` is `receive_message` wait time
-# (dominated by inter-message gap / prefetch drain), NOT a read cost, and is
-# inherently noisy — a small-number current-vs-baseline delta easily trips the
-# global `*_latency_*` regression threshold. The meaningful read-side latency is
-# the custom `topic_e2e_latency_*` (write -> read). So keep read_latency visible
-# but INFORMATIONAL (never warns/fails) for topics; `write_latency` (the real
-# ack round-trip) and table/query keep the strict global thresholds.
+# What's made `direction: neutral` (visible in the report, but never warns/fails):
+#
+# - read_latency_* — for topics this is `receive_message` wait time (inter-message
+#   gap / prefetch drain), NOT a read cost; the meaningful read-side latency is
+#   the custom `topic_e2e_latency_*`.
+#
+# - *_p99 tails (write + e2e) — under chaos the p99 is dominated by node-kill
+#   outage spikes, and for async it also carries single-event-loop scheduling
+#   jitter; both are uncorrelated between the current and baseline containers, so
+#   the p99 current-vs-baseline delta is noise, not a regression signal.
+#
+# Kept gated (strict global thresholds): write_latency p50/p95 (ack round-trip),
+# topic_e2e_latency_p50 (the real delivery latency), topic_delivered_rps,
+# topic_lost_errors, read/write availability. table/query are untouched.
 
 metrics:
   - name: read_latency_p50_ms
@@ -18,4 +25,8 @@ metrics:
   - name: read_latency_p95_ms
     direction: neutral
   - name: read_latency_p99_ms
+    direction: neutral
+  - name: write_latency_p99_ms
+    direction: neutral
+  - name: topic_e2e_latency_p99_ms
     direction: neutral

--- a/tests/slo/thresholds-topic.yaml
+++ b/tests/slo/thresholds-topic.yaml
@@ -1,0 +1,21 @@
+# Per-scenario SLO thresholds for the topic workloads, merged OVER the action's
+# global deploy/thresholds.yaml for topic runs only (via the init action's
+# `thresholds_yaml_path` input — see ydb-slo-action PR #57 "per-scenario
+# threshold overrides"). On an action version without that feature this file is
+# simply ignored, so wiring it is harmless and self-activates once it lands.
+#
+# Why: for topics the generic `read_latency` is `receive_message` wait time
+# (dominated by inter-message gap / prefetch drain), NOT a read cost, and is
+# inherently noisy — a small-number current-vs-baseline delta easily trips the
+# global `*_latency_*` regression threshold. The meaningful read-side latency is
+# the custom `topic_e2e_latency_*` (write -> read). So keep read_latency visible
+# but INFORMATIONAL (never warns/fails) for topics; `write_latency` (the real
+# ack round-trip) and table/query keep the strict global thresholds.
+
+metrics:
+  - name: read_latency_p50_ms
+    direction: neutral
+  - name: read_latency_p95_ms
+    direction: neutral
+  - name: read_latency_p99_ms
+    direction: neutral


### PR DESCRIPTION
Extends the SLO suite with new label-driven workloads and hardens the topic path.

### Workloads (selected by the `WORKLOAD_NAME` label; `async-*` runs the `ydb.aio` path)
- **async-query** — query-service workload on `ydb.aio` (closed-loop, mirrors the sync model for comparable metrics).
- **sync-topic / async-topic** — topic workloads that **validate end-to-end delivery and per-producer ordering** under chaos: partition-pinned writers with a stable ref-scoped `producer_id`; readers demux by `writer_id` and track the next expected seqno (shared, so a consumer-group rebalance doesn't report a false gap). A forward gap = **lost** (fails the run via the `*_error*` threshold); a backward seqno = **duplicate** (reconnect redelivery, informational); plus **end-to-end latency** (write→read, same process). New topic metrics surfaced via `tests/slo/metrics-topic.yaml` (merged through `metrics_yaml_path`). See `tests/slo/TOPIC_SCENARIO.md`.

### Hang-proofing (topic)
The SLO caught a real hang: under chaos the async topic writer wedged in the SDK's GZIP encode executor (`cannot schedule new futures after shutdown`) and, awaited without a timeout, silently stalled the run at ~half duration. Hardened so this can never silently hang: every `write_with_ack`/`receive_message`/`commit_with_ack` is bounded by a timeout, the writer/reader self-heal (recreate on failure, seqno persists), and the codec is `RAW` (skips the buggy executor path; RAW==GZIP throughput on small messages). The underlying SDK bug is tracked in #852.

### Workflow fixes
- SLO only (re)triggers when the `SLO` label itself is added — unrelated label changes (e.g. the AI-review bot) no longer spawn a run that cancels the in-progress one.
- `slo-report` consumes the label / publishes only on a genuine `success`/`failure`, not on `cancelled` (so a superseded run no longer strips the label mid-flight).

### Notes
- Topic profile set to **200 rps / 8 writers / 8 readers / 8 partitions** — a reliable point comfortably below the observed chaos ceiling (async self-balances ~266 rps; at 1000 rps the reader can't keep up).
- Backward-compatible: only extends `tests/slo/`, `ydb/` (the SDK) is unchanged.