### PR TITLE
Make missing row attribute access both AttributeError and KeyError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,12 @@ source .venv/bin/activate && tox -e py -- tests/path/to/test_file.py -v
 6. **English only** — code, comments, docstrings, commit messages.
 7. **Python 3.8+** — do not use language or stdlib features beyond that baseline.
 
+## CHANGELOG
+
+- Add a single line to the top of `CHANGELOG.md` **only** when a change is meaningful to the end user — new or changed behavior, a bug fix, a performance or compatibility improvement.
+- Do **not** add entries for internal-only work such as tests, coverage, CI, refactors, or documentation.
+- **Never add a version header** (`## X.Y.Z ##`) by hand — release automation inserts it above the pending lines. Just prepend the bullet.
+
 ## Documentation & Examples
 
 - Update `docs/` for any user-facing changes; create new sections if needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Make missing row/struct attribute access raise an error that is both AttributeError and KeyError, to stay backward compatible with callers written against the pre-3.29.5 KeyError
+
 ## 3.29.6 ##
 * Restore attribute assignment on query result set rows (broken by the result set memory optimization)
 

--- a/ydb/convert.py
+++ b/ydb/convert.py
@@ -23,6 +23,15 @@ def _initialize():
 _initialize()
 
 
+class _MissingItemError(AttributeError, KeyError):
+    # Dotted access to a missing row/struct field used to leak KeyError; since
+    # 3.29.5 it raises AttributeError (the correct protocol, e.g. for hasattr
+    # and copy). This combined type is both, so callers that still catch
+    # KeyError — as they had to before 3.29.5 — keep working alongside the new
+    # AttributeError. Prefer catching AttributeError in new code.
+    __slots__ = ()
+
+
 class _DotDict(dict):
     # A lazy __dict__ is declared on purpose: it is not materialized until a row
     # is written to (or its __dict__ is introspected), so untouched read-only
@@ -38,7 +47,7 @@ class _DotDict(dict):
         try:
             return self[item]
         except KeyError:
-            raise AttributeError(item) from None
+            raise _MissingItemError(item) from None
 
 
 def _is_decimal_signed(hi_value):

--- a/ydb/table_test.py
+++ b/ydb/table_test.py
@@ -102,6 +102,23 @@ def test_result_set_row_missing_attribute_raises_attribute_error():
         row.definitely_missing
 
 
+def test_result_set_row_missing_attribute_is_also_key_error():
+    # Before 3.29.5 dotted access to a missing field leaked KeyError; it now
+    # raises AttributeError. The combined error stays catchable as either, so
+    # callers written against the old behaviour keep working.
+    message = _build_int_result_set(n_rows=1, n_cols=1)
+    row = convert.ResultSet.from_message(message).rows[0]
+
+    with pytest.raises(KeyError):
+        row.definitely_missing
+
+    try:
+        row.definitely_missing
+    except Exception as e:
+        assert isinstance(e, AttributeError)
+        assert isinstance(e, KeyError)
+
+
 def test_result_set_row_is_copyable():
     message = _build_int_result_set(n_rows=1, n_cols=3)
     row = convert.ResultSet.from_message(message).rows[0]


### PR DESCRIPTION
Since 3.29.5, dotted access to a missing row/struct field (`row.missing`) raises `AttributeError` instead of the former `KeyError`, which can silently break callers that catch `KeyError`.

This makes the error a subclass of both `AttributeError` and `KeyError`, so old and new catchers both work; `hasattr`/`copy` stay correct since it remains an `AttributeError`.