### PR TITLE
Accept native datetime for Datetime and Datetime64 query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Accept native `datetime.datetime` values for `Datetime` and `Datetime64` query parameters (previously only integer seconds since the epoch were accepted)
+
 ## 3.29.7 ##
 * Make missing row/struct attribute access raise an error that is both AttributeError and KeyError, to stay backward compatible with callers written against the pre-3.29.5 KeyError
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -184,6 +184,14 @@ Date and time
    * - ``PrimitiveType.Interval64``
      - extended-range interval
 
+.. note::
+
+   When a ``datetime.datetime`` is passed for ``Datetime``, ``Datetime64``,
+   ``Timestamp`` or ``Timestamp64``, a tz-naive value is written as-is (its
+   wall-clock value), while a tz-aware value is converted to UTC first.
+   Integer inputs (seconds for ``Datetime``/``Datetime64``, microseconds for
+   ``Timestamp``/``Timestamp64`` since the Unix epoch) are still accepted.
+
 Other
 ^^^^^
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -176,13 +176,13 @@ Date and time
    * - ``PrimitiveType.Interval``
      - duration; maps to/from ``datetime.timedelta``
    * - ``PrimitiveType.Date32``
-     - extended-range date (supports negative years)
+     - extended-range date (supports negative years); maps to/from ``datetime.date``
    * - ``PrimitiveType.Datetime64``
      - extended-range datetime (second precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Timestamp64``
      - extended-range timestamp (microsecond precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Interval64``
-     - extended-range interval
+     - extended-range interval; maps to/from ``datetime.timedelta``
 
 .. note::
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -170,7 +170,7 @@ Date and time
    * - ``PrimitiveType.Date``
      - calendar date; maps to/from ``datetime.date``
    * - ``PrimitiveType.Datetime``
-     - date + time without timezone (second precision)
+     - date + time without timezone (second precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Timestamp``
      - date + time without timezone (microsecond precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Interval``
@@ -178,9 +178,9 @@ Date and time
    * - ``PrimitiveType.Date32``
      - extended-range date (supports negative years)
    * - ``PrimitiveType.Datetime64``
-     - extended-range datetime (second precision)
+     - extended-range datetime (second precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Timestamp64``
-     - extended-range timestamp (microsecond precision)
+     - extended-range timestamp (microsecond precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Interval64``
      - extended-range interval
 

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -65,6 +65,7 @@ tz4h = timezone(timedelta(hours=4))
         (datetime(1971, 1, 1, 0, 0), "Datetime", datetime(1971, 1, 1, 0, 0)),
         (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), "Datetime", datetime(1970, 1, 1, 0, 0)),
         (datetime(1969, 1, 1, 0, 0), "Datetime64", datetime(1969, 1, 1, 0, 0)),
+        (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), "Datetime64", datetime(1970, 1, 1, 0, 0)),
         (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), "Timestamp", datetime(1970, 1, 1, 0, 0)),
         (test_td, "Interval", test_td),
         (test_now, "Timestamp", test_now),

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -59,11 +59,12 @@ tz4h = timezone(timedelta(hours=4))
 @pytest.mark.parametrize(
     "value,ydb_type,result_value",
     [
-        # FIXME: TypeError: 'datetime.datetime' object cannot be interpreted as an integer
-        # (test_dt_today, "Datetime", test_dt_today),
         (test_today, "Date", test_today),
         (365, "Date", date(1971, 1, 1)),
         (3600 * 24 * 365, "Datetime", datetime(1971, 1, 1, 0, 0)),
+        (datetime(1971, 1, 1, 0, 0), "Datetime", datetime(1971, 1, 1, 0, 0)),
+        (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), "Datetime", datetime(1970, 1, 1, 0, 0)),
+        (datetime(1969, 1, 1, 0, 0), "Datetime64", datetime(1969, 1, 1, 0, 0)),
         (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), "Timestamp", datetime(1970, 1, 1, 0, 0)),
         (test_td, "Interval", test_td),
         (test_now, "Timestamp", test_now),

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -95,6 +95,7 @@ tz4h = timezone(timedelta(hours=4))
         (3600 * 24 * 365 * (-1), ydb.PrimitiveType.Datetime64, datetime(1969, 1, 1, 0, 0)),
         (datetime(1969, 1, 1, 0, 0), ydb.PrimitiveType.Datetime64, datetime(1969, 1, 1, 0, 0)),
         (test_old_date, ydb.PrimitiveType.Datetime64, test_old_date),
+        (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), ydb.PrimitiveType.Datetime64, datetime(1970, 1, 1, 0, 0)),
         (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), ydb.PrimitiveType.Timestamp, datetime(1970, 1, 1, 0, 0)),
         (test_td, ydb.PrimitiveType.Interval, test_td),
         (test_td, ydb.PrimitiveType.Interval64, test_td),

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -86,13 +86,15 @@ tz4h = timezone(timedelta(hours=4))
 @pytest.mark.parametrize(
     "value,ydb_type,result_value",
     [
-        # FIXME: TypeError: 'datetime.datetime' object cannot be interpreted as an integer
-        # (test_dt_today, "Datetime", test_dt_today),
         (test_today, ydb.PrimitiveType.Date, test_today),
         (365, ydb.PrimitiveType.Date, date(1971, 1, 1)),
         (-365, ydb.PrimitiveType.Date32, date(1969, 1, 1)),
         (3600 * 24 * 365, ydb.PrimitiveType.Datetime, datetime(1971, 1, 1, 0, 0)),
+        (datetime(1971, 1, 1, 0, 0), ydb.PrimitiveType.Datetime, datetime(1971, 1, 1, 0, 0)),
+        (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), ydb.PrimitiveType.Datetime, datetime(1970, 1, 1, 0, 0)),
         (3600 * 24 * 365 * (-1), ydb.PrimitiveType.Datetime64, datetime(1969, 1, 1, 0, 0)),
+        (datetime(1969, 1, 1, 0, 0), ydb.PrimitiveType.Datetime64, datetime(1969, 1, 1, 0, 0)),
+        (test_old_date, ydb.PrimitiveType.Datetime64, test_old_date),
         (datetime(1970, 1, 1, 4, 0, tzinfo=tz4h), ydb.PrimitiveType.Timestamp, datetime(1970, 1, 1, 0, 0)),
         (test_td, ydb.PrimitiveType.Interval, test_td),
         (test_td, ydb.PrimitiveType.Interval64, test_td),
@@ -123,7 +125,9 @@ def test_types_native(driver_sync, value, ydb_type, result_value):
         (365, ydb.PrimitiveType.Date, "1971-01-01", date(1971, 1, 1)),
         (-365, ydb.PrimitiveType.Date32, "1969-01-01", date(1969, 1, 1)),
         (3600 * 24 * 365, ydb.PrimitiveType.Datetime, "1971-01-01T00:00:00Z", datetime(1971, 1, 1, 0, 0)),
+        (datetime(1971, 1, 1, 0, 0), ydb.PrimitiveType.Datetime, "1971-01-01T00:00:00Z", datetime(1971, 1, 1, 0, 0)),
         (3600 * 24 * 365 * (-1), ydb.PrimitiveType.Datetime64, "1969-01-01T00:00:00Z", datetime(1969, 1, 1, 0, 0)),
+        (datetime(1969, 1, 1, 0, 0), ydb.PrimitiveType.Datetime64, "1969-01-01T00:00:00Z", datetime(1969, 1, 1, 0, 0)),
         (
             datetime(1970, 1, 1, 4, 0, tzinfo=tz4h),
             ydb.PrimitiveType.Timestamp,

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -64,6 +64,22 @@ def _from_datetime_number(
     return x
 
 
+def _to_datetime(pb: ydb_value_pb2.Value, value: typing.Union[datetime, int]) -> None:
+    if isinstance(value, datetime):
+        epoch = _EPOCH_UTC if value.tzinfo else _EPOCH
+        pb.uint32_value = (value - epoch) // timedelta(seconds=1)
+    else:
+        pb.uint32_value = value
+
+
+def _to_datetime64(pb: ydb_value_pb2.Value, value: typing.Union[datetime, int]) -> None:
+    if isinstance(value, datetime):
+        epoch = _EPOCH_UTC if value.tzinfo else _EPOCH
+        pb.int64_value = (value - epoch) // timedelta(seconds=1)
+    else:
+        pb.int64_value = value
+
+
 def _from_json(x: typing.Union[str, bytearray, bytes], table_client_settings: table.TableClientSettings) -> typing.Any:
     if table_client_settings is not None and table_client_settings._native_json_in_result_sets:
         return json.loads(x)
@@ -178,11 +194,13 @@ class PrimitiveType(enum.Enum):
         _apis.primitive_types.DATETIME,
         "uint32_value",
         _from_datetime_number,
+        _to_datetime,
     )
     Datetime64 = (
         _apis.primitive_types.DATETIME64,
         "int64_value",
         _from_datetime_number,
+        _to_datetime64,
     )
     Timestamp = (
         _apis.primitive_types.TIMESTAMP,


### PR DESCRIPTION
Fixes #709.

`Datetime` and `Datetime64` query parameters now accept `datetime.datetime` (naive treated as epoch, tz-aware converted via UTC), in addition to the integer epoch seconds already supported. `Timestamp`/`Timestamp64` already accepted `datetime`; only these two types lacked a write-side converter.

The reader path is unchanged (`proto_field` kept), so `get_value` still returns `datetime` as before.