### PR TITLE
Drop Python 3.8/3.9 support

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,9 +40,9 @@ jobs:
         token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         environment: [style, black, mypy]
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         protobuf-version: [proto3, proto4, proto5, proto6]
         exclude:
           # protobuf 4.x cannot be imported on Python 3.14: its C extension uses
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ source .venv/bin/activate && tox -e py -- tests/path/to/test_file.py -v
 4. **No new dependencies** — the current dependency set is intentionally minimal.
 5. **No excessive comments** — do not comment self-evident code.
 6. **English only** — code, comments, docstrings, commit messages.
-7. **Python 3.8+** — do not use language or stdlib features beyond that baseline.
+7. **Python 3.10+** — do not use language or stdlib features beyond that baseline.
 
 ## CHANGELOG
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@ This document has detailed instructions on how to build ydb-python-sdk from sour
 ### Pre-requisites
 
 - Install [Docker](https://docs.docker.com/engine/install/).
-- Install [Python](https://docs.python.org/3.8/)
+- Install [Python](https://docs.python.org/3.10/)
 - Install [pip](https://pip.pypa.io/en/latest/installation/)
 - Install [Tox](https://tox.wiki/en/latest/installation.html)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Drop support for Python 3.8 and 3.9; the minimum supported version is now Python 3.10
 * Accept native `datetime.datetime` values for `Datetime` and `Datetime64` query parameters (previously only integer seconds since the epoch were accepted)
 
 ## 3.29.7 ##

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Officially supported Python client for YDB.
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 - `pip` version 9.0.1 or higher
 
 If necessary, upgrade your version of `pip`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 120
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 warn_redundant_casts = true
 strict_equality = true

--- a/setup.py
+++ b/setup.py
@@ -25,16 +25,14 @@ setuptools.setup(
     packages=setuptools.find_packages("."),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
     ],
+    python_requires=">=3.10",
     install_requires=requirements,  # requirements.txt
-    options={"bdist_wheel": {"universal": True}},
     extras_require={
         "yc": ["yandexcloud", ],
         "opentelemetry": ["opentelemetry-api>=1.0.0"],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 attrs==21.2.0
 bcrypt==3.2.0
-black==25.11.0; python_version >= "3.9"
+black==25.11.0
 cached-property==1.5.2
 certifi==2024.7.4
 cffi>=1.17.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,10 +110,11 @@ class DockerProject:
 
     The `stop()` method talks to the Docker daemon via the SDK (unix socket)
     instead of forking a `docker compose kill` subprocess. Forking from a
-    python process that has active gRPC threads crashes the child with
-    SIGABRT on Python 3.9 (long-standing gRPC fork-handler issue), and
-    `stop()` is the worst offender because the driver is in the middle of
-    busy traffic when it's called.
+    python process that has active gRPC threads can crash the child with
+    SIGABRT (a long-standing gRPC fork-handler issue; not tied to any single
+    Python version — still observed on 3.10+ in CI), and `stop()` is the
+    worst offender because the driver is in the middle of busy traffic when
+    it's called.
 
     `start()` still uses `docker compose up -d --force-recreate` because
     recreating a YDB container after SIGKILL needs the full compose config
@@ -208,7 +209,7 @@ def endpoint(request):
     # test actually needs the container. The compose file publishes a fixed
     # host port, so avoid `port_for()` — it shells out to `docker compose
     # port`, which is exactly the late subprocess path that can trip the
-    # Python 3.9 gRPC fork race.
+    # gRPC fork race (see DockerProject; not Python-3.9-specific).
     docker_services = request.getfixturevalue("docker_services")
     endpoint_url = f"localhost:{YDB_ENDPOINT_PORT}"
     docker_services.wait_until_responsive(

--- a/ydb/convert.py
+++ b/ydb/convert.py
@@ -11,7 +11,7 @@ _SIGN_BIT = 2**63
 _DecimalNanRepr = 10**35 + 1
 _DecimalInfRepr = 10**35
 _DecimalSignedInfRepr = -(10**35)
-_primitive_type_by_id = {}
+_primitive_type_by_id: dict[int, types.PrimitiveType] = {}
 _default_allow_truncated_result = False
 
 

--- a/ydb/export.py
+++ b/ydb/export.py
@@ -17,7 +17,7 @@ from . import operation
 
 _ExportToYt = "ExportToYt"
 _ExportToS3 = "ExportToS3"
-_progresses = {}
+_progresses: "dict[int, ExportProgress]" = {}
 
 
 @enum.unique

--- a/ydb/import_client.py
+++ b/ydb/import_client.py
@@ -17,7 +17,7 @@ else:
 from . import operation
 
 _ImportFromS3 = "ImportFromS3"
-_progresses = {}
+_progresses: "dict[int, ImportProgress]" = {}
 
 
 @enum.unique


### PR DESCRIPTION
Raises the minimum supported runtime to **Python 3.10**.

- `python_requires>=3.10`; drop 3.8/3.9 classifiers and CI matrix cells
- `mypy` target `python_version = 3.10`
- Refresh docs and reword stale Python-3.9 comments in the test harness
