### PR TITLE
Support TzDate, TzDatetime and TzTimestamp types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Support the timezone-carrying types `TzDate`, `TzDatetime` and `TzTimestamp` in query results and parameters (reading them previously raised `AttributeError`)
 * Drop support for Python 3.8 and 3.9; the minimum supported version is now Python 3.10
 * Accept native `datetime.datetime` values for `Datetime` and `Datetime64` query parameters (previously only integer seconds since the epoch were accepted)
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -202,11 +202,12 @@ Date and time
 
    ``TzDate``, ``TzDatetime`` and ``TzTimestamp`` carry an IANA timezone name.
    On write, pass a tz-aware ``datetime.datetime`` whose ``tzinfo`` is a
-   ``zoneinfo.ZoneInfo`` — its local wall-clock and zone name are stored. On
-   read, they are returned as tz-aware ``datetime.datetime`` values (``TzDate``
-   at midnight in that zone). When the matching
-   ``with_native_*_in_result_sets`` option is disabled, the raw
-   ``"<value>,<zone>"`` string is returned instead.
+   ``zoneinfo.ZoneInfo`` — its local wall-clock and zone name are stored; any
+   other ``tzinfo`` raises ``ValueError``. On read, they are returned as
+   tz-aware ``datetime.datetime`` values (``TzDate`` at midnight in that zone),
+   or the raw ``"<value>,<zone>"`` string when the matching
+   ``with_native_*_in_result_sets`` option is disabled or the zone cannot be
+   loaded from the system timezone database (e.g. no ``tzdata`` installed).
 
 Other
 ^^^^^

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -206,8 +206,9 @@ Date and time
    other ``tzinfo`` raises ``ValueError``. On read, they are returned as
    tz-aware ``datetime.datetime`` values (``TzDate`` at midnight in that zone),
    or the raw ``"<value>,<zone>"`` string when the matching
-   ``with_native_*_in_result_sets`` option is disabled or the zone cannot be
-   loaded from the system timezone database (e.g. no ``tzdata`` installed).
+   ``with_native_*_in_result_sets`` option is disabled. Resolving the zone name
+   needs a timezone database; if it is unavailable (e.g. no ``tzdata``
+   installed) reading such a value raises ``zoneinfo.ZoneInfoNotFoundError``.
 
 Other
 ^^^^^

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -183,6 +183,12 @@ Date and time
      - extended-range timestamp (microsecond precision); maps to/from ``datetime.datetime``
    * - ``PrimitiveType.Interval64``
      - extended-range interval; maps to/from ``datetime.timedelta``
+   * - ``PrimitiveType.TzDate``
+     - date with a timezone name; maps to/from a tz-aware ``datetime.datetime`` at midnight
+   * - ``PrimitiveType.TzDatetime``
+     - date + time with a timezone name (second precision); maps to/from a tz-aware ``datetime.datetime``
+   * - ``PrimitiveType.TzTimestamp``
+     - date + time with a timezone name (microsecond precision); maps to/from a tz-aware ``datetime.datetime``
 
 .. note::
 
@@ -191,6 +197,16 @@ Date and time
    wall-clock value), while a tz-aware value is converted to UTC first.
    Integer inputs (seconds for ``Datetime``/``Datetime64``, microseconds for
    ``Timestamp``/``Timestamp64`` since the Unix epoch) are still accepted.
+
+.. note::
+
+   ``TzDate``, ``TzDatetime`` and ``TzTimestamp`` carry an IANA timezone name.
+   On write, pass a tz-aware ``datetime.datetime`` whose ``tzinfo`` is a
+   ``zoneinfo.ZoneInfo`` — its local wall-clock and zone name are stored. On
+   read, they are returned as tz-aware ``datetime.datetime`` values (``TzDate``
+   at midnight in that zone). When the matching
+   ``with_native_*_in_result_sets`` option is disabled, the raw
+   ``"<value>,<zone>"`` string is returned instead.
 
 Other
 ^^^^^

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -4,6 +4,7 @@ import ydb
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(
@@ -39,6 +40,9 @@ from uuid import uuid4
         (-100, "Interval"),
         (100, "Timestamp"),
         (1511789040123456, "Timestamp"),
+        ("2019-09-17,Europe/Moscow", "TzDate"),
+        ("2019-09-16T18:24:00,Europe/Moscow", "TzDatetime"),
+        ("2019-09-16T18:24:00.123456,Europe/Moscow", "TzTimestamp"),
     ],
 )
 @pytest.mark.asyncio
@@ -54,6 +58,7 @@ test_now = datetime.utcnow()
 test_today = test_now.date()
 test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
+tzmsk = ZoneInfo("Europe/Moscow")
 
 
 @pytest.mark.parametrize(
@@ -76,6 +81,13 @@ tz4h = timezone(timedelta(hours=4))
         ),
         ('{"foo": "bar"}', "Json", {"foo": "bar"}),
         ('{"foo": "bar"}', "JsonDocument", {"foo": "bar"}),
+        (datetime(2019, 9, 17, tzinfo=tzmsk), "TzDate", datetime(2019, 9, 17, tzinfo=tzmsk)),
+        (datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk), "TzDatetime", datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk)),
+        (
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            "TzTimestamp",
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -4,7 +4,7 @@ import ydb
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,11 @@ test_now = datetime.utcnow()
 test_today = test_now.date()
 test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
-tzmsk = ZoneInfo("Europe/Moscow")
+try:
+    tzmsk = ZoneInfo("Europe/Moscow")
+except ZoneInfoNotFoundError:  # no system tzdata / tzdata wheel on this platform
+    tzmsk = None
+requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone database (tzdata) not available")
 
 
 @pytest.mark.parametrize(
@@ -81,12 +85,23 @@ tzmsk = ZoneInfo("Europe/Moscow")
         ),
         ('{"foo": "bar"}', "Json", {"foo": "bar"}),
         ('{"foo": "bar"}', "JsonDocument", {"foo": "bar"}),
-        (datetime(2019, 9, 17, tzinfo=tzmsk), "TzDate", datetime(2019, 9, 17, tzinfo=tzmsk)),
-        (datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk), "TzDatetime", datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk)),
-        (
+        pytest.param(
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+            "TzDate",
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+            marks=requires_tzdata,
+        ),
+        pytest.param(
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            "TzDatetime",
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            marks=requires_tzdata,
+        ),
+        pytest.param(
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             "TzTimestamp",
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
     ],
 )

--- a/tests/aio/test_types.py
+++ b/tests/aio/test_types.py
@@ -60,8 +60,9 @@ test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
 try:
     tzmsk = ZoneInfo("Europe/Moscow")
+    tzny = ZoneInfo("America/New_York")
 except ZoneInfoNotFoundError:  # no system tzdata / tzdata wheel on this platform
-    tzmsk = None
+    tzmsk = tzny = None
 requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone database (tzdata) not available")
 
 
@@ -101,6 +102,12 @@ requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone data
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             "TzTimestamp",
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            marks=requires_tzdata,
+        ),
+        pytest.param(
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
+            "TzDatetime",
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
             marks=requires_tzdata,
         ),
     ],

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -190,10 +190,11 @@ def test_type_str_repr(driver_sync, value, ydb_type, str_repr, result_value):
 
 
 def test_tz_conversion_fallbacks():
-    # Defensive branches a real-server round-trip never reaches: an unresolvable
-    # zone name is passed through as raw text, and a non-ZoneInfo tzinfo falls
-    # back to its str() name.
+    # Edge branches a real-server round-trip never reaches: an unresolvable zone
+    # name is passed through as raw text on read, and a non-ZoneInfo tzinfo is
+    # rejected on write.
     from ydb.types import _parse_tz, _tz_name
 
     assert _parse_tz("2019-09-16T18:24:00,Not/AZone") == "2019-09-16T18:24:00,Not/AZone"
-    assert _tz_name(datetime(2019, 9, 17, tzinfo=timezone.utc)) == "UTC"
+    with pytest.raises(ValueError):
+        _tz_name(datetime(2019, 9, 17, tzinfo=tz4h))

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -207,10 +207,14 @@ def test_tz_conversion_fallbacks():
     # Edge branches a real-server round-trip never reaches: an unresolvable zone
     # name is passed through as raw text on read, and a non-ZoneInfo tzinfo is
     # rejected on write.
-    from ydb.types import _parse_tz, _tz_name
+    from ydb.types import _parse_tz
+    from ydb._grpc.common.protos import ydb_value_pb2
 
     assert _parse_tz("2019-09-16T18:24:00,Not/AZone") == "2019-09-16T18:24:00,Not/AZone"
     # no comma -> empty zone name -> ZoneInfo("") raises ValueError -> raw text
     assert _parse_tz("2019-09-16T18:24:00") == "2019-09-16T18:24:00"
-    with pytest.raises(ValueError):
-        _tz_name(datetime(2019, 9, 17, tzinfo=tz4h))
+    # a datetime without a ZoneInfo tzinfo is rejected on write: a naive value
+    # (no timezone at all) and a fixed-offset value both raise ValueError.
+    for bad in (datetime(2019, 9, 17), datetime(2019, 9, 17, tzinfo=tz4h)):
+        with pytest.raises(ValueError):
+            ydb.PrimitiveType.TzDatetime.set_value(ydb_value_pb2.Value(), bad)

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -87,8 +87,9 @@ test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
 try:
     tzmsk = ZoneInfo("Europe/Moscow")
+    tzny = ZoneInfo("America/New_York")
 except ZoneInfoNotFoundError:  # no system tzdata / tzdata wheel on this platform
-    tzmsk = None
+    tzmsk = tzny = None
 requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone database (tzdata) not available")
 
 
@@ -133,6 +134,12 @@ requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone data
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             ydb.PrimitiveType.TzTimestamp,
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            marks=requires_tzdata,
+        ),
+        pytest.param(
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
+            ydb.PrimitiveType.TzDatetime,
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
             marks=requires_tzdata,
         ),
     ],
@@ -186,6 +193,13 @@ def test_types_native(driver_sync, value, ydb_type, result_value):
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             marks=requires_tzdata,
         ),
+        pytest.param(
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
+            ydb.PrimitiveType.TzDatetime,
+            "2019-09-16T12:00:00,America/New_York",
+            datetime(2019, 9, 16, 12, 0, tzinfo=tzny),
+            marks=requires_tzdata,
+        ),
     ],
 )
 def test_type_str_repr(driver_sync, value, ydb_type, str_repr, result_value):
@@ -210,9 +224,12 @@ def test_tz_conversion_fallbacks():
     from ydb.types import _parse_tz
     from ydb._grpc.common.protos import ydb_value_pb2
 
-    assert _parse_tz("2019-09-16T18:24:00,Not/AZone") == "2019-09-16T18:24:00,Not/AZone"
-    # no comma -> empty zone name -> ZoneInfo("") raises ValueError -> raw text
-    assert _parse_tz("2019-09-16T18:24:00") == "2019-09-16T18:24:00"
+    # an unresolvable zone raises rather than silently returning the raw text
+    with pytest.raises(ZoneInfoNotFoundError):
+        _parse_tz("2019-09-16T18:24:00,Not/AZone")
+    # no comma -> empty zone name -> ZoneInfo("") raises ValueError
+    with pytest.raises(ValueError):
+        _parse_tz("2019-09-16T18:24:00")
     # a datetime without a ZoneInfo tzinfo is rejected on write: a naive value
     # (no timezone at all) and a fixed-offset value both raise ValueError.
     for bad in (datetime(2019, 9, 17), datetime(2019, 9, 17, tzinfo=tz4h)):

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -4,7 +4,7 @@ import ydb
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,11 @@ test_old_date = datetime(1221, 1, 1, 0, 0)
 test_today = test_now.date()
 test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
-tzmsk = ZoneInfo("Europe/Moscow")
+try:
+    tzmsk = ZoneInfo("Europe/Moscow")
+except ZoneInfoNotFoundError:  # no system tzdata / tzdata wheel on this platform
+    tzmsk = None
+requires_tzdata = pytest.mark.skipif(tzmsk is None, reason="system timezone database (tzdata) not available")
 
 
 @pytest.mark.parametrize(
@@ -113,16 +117,23 @@ tzmsk = ZoneInfo("Europe/Moscow")
         ),
         ('{"foo": "bar"}', ydb.PrimitiveType.Json, {"foo": "bar"}),
         ('{"foo": "bar"}', ydb.PrimitiveType.JsonDocument, {"foo": "bar"}),
-        (datetime(2019, 9, 17, tzinfo=tzmsk), ydb.PrimitiveType.TzDate, datetime(2019, 9, 17, tzinfo=tzmsk)),
-        (
+        pytest.param(
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzDate,
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+            marks=requires_tzdata,
+        ),
+        pytest.param(
             datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
             ydb.PrimitiveType.TzDatetime,
             datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
-        (
+        pytest.param(
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             ydb.PrimitiveType.TzTimestamp,
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
     ],
 )
@@ -154,23 +165,26 @@ def test_types_native(driver_sync, value, ydb_type, result_value):
         (test_td, ydb.PrimitiveType.Interval, "-PT0.0001S", test_td),
         (test_td, ydb.PrimitiveType.Interval64, "-PT0.0001S", test_td),
         (test_old_date, ydb.PrimitiveType.Timestamp64, "1221-01-01T00:00:00Z", test_old_date),
-        (
+        pytest.param(
             datetime(2019, 9, 17, tzinfo=tzmsk),
             ydb.PrimitiveType.TzDate,
             "2019-09-17,Europe/Moscow",
             datetime(2019, 9, 17, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
-        (
+        pytest.param(
             datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
             ydb.PrimitiveType.TzDatetime,
             "2019-09-16T18:24:00,Europe/Moscow",
             datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
-        (
+        pytest.param(
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
             ydb.PrimitiveType.TzTimestamp,
             "2019-09-16T18:24:00.123456,Europe/Moscow",
             datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            marks=requires_tzdata,
         ),
     ],
 )
@@ -196,5 +210,7 @@ def test_tz_conversion_fallbacks():
     from ydb.types import _parse_tz, _tz_name
 
     assert _parse_tz("2019-09-16T18:24:00,Not/AZone") == "2019-09-16T18:24:00,Not/AZone"
+    # no comma -> empty zone name -> ZoneInfo("") raises ValueError -> raw text
+    assert _parse_tz("2019-09-16T18:24:00") == "2019-09-16T18:24:00"
     with pytest.raises(ValueError):
         _tz_name(datetime(2019, 9, 17, tzinfo=tz4h))

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -4,6 +4,7 @@ import ydb
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(
@@ -56,6 +57,9 @@ from uuid import uuid4
         (1511789040123456, ydb.PrimitiveType.Timestamp),
         (1511789040123456, ydb.PrimitiveType.Timestamp64),
         (-1511789040123456, ydb.PrimitiveType.Timestamp64),
+        ("2019-09-17,Europe/Moscow", ydb.PrimitiveType.TzDate),
+        ("2019-09-16T18:24:00,Europe/Moscow", ydb.PrimitiveType.TzDatetime),
+        ("2019-09-16T18:24:00.123456,Europe/Moscow", ydb.PrimitiveType.TzTimestamp),
     ],
 )
 def test_types(driver_sync: ydb.Driver, value, ydb_type):
@@ -81,6 +85,7 @@ test_old_date = datetime(1221, 1, 1, 0, 0)
 test_today = test_now.date()
 test_dt_today = datetime.today()
 tz4h = timezone(timedelta(hours=4))
+tzmsk = ZoneInfo("Europe/Moscow")
 
 
 @pytest.mark.parametrize(
@@ -108,6 +113,17 @@ tz4h = timezone(timedelta(hours=4))
         ),
         ('{"foo": "bar"}', ydb.PrimitiveType.Json, {"foo": "bar"}),
         ('{"foo": "bar"}', ydb.PrimitiveType.JsonDocument, {"foo": "bar"}),
+        (datetime(2019, 9, 17, tzinfo=tzmsk), ydb.PrimitiveType.TzDate, datetime(2019, 9, 17, tzinfo=tzmsk)),
+        (
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzDatetime,
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+        ),
+        (
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzTimestamp,
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+        ),
     ],
 )
 def test_types_native(driver_sync, value, ydb_type, result_value):
@@ -138,6 +154,24 @@ def test_types_native(driver_sync, value, ydb_type, result_value):
         (test_td, ydb.PrimitiveType.Interval, "-PT0.0001S", test_td),
         (test_td, ydb.PrimitiveType.Interval64, "-PT0.0001S", test_td),
         (test_old_date, ydb.PrimitiveType.Timestamp64, "1221-01-01T00:00:00Z", test_old_date),
+        (
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzDate,
+            "2019-09-17,Europe/Moscow",
+            datetime(2019, 9, 17, tzinfo=tzmsk),
+        ),
+        (
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzDatetime,
+            "2019-09-16T18:24:00,Europe/Moscow",
+            datetime(2019, 9, 16, 18, 24, tzinfo=tzmsk),
+        ),
+        (
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+            ydb.PrimitiveType.TzTimestamp,
+            "2019-09-16T18:24:00.123456,Europe/Moscow",
+            datetime(2019, 9, 16, 18, 24, 0, 123456, tzinfo=tzmsk),
+        ),
     ],
 )
 def test_type_str_repr(driver_sync, value, ydb_type, str_repr, result_value):

--- a/tests/query/test_types.py
+++ b/tests/query/test_types.py
@@ -187,3 +187,13 @@ def test_type_str_repr(driver_sync, value, ydb_type, str_repr, result_value):
             {"$param": (str_repr, ydb.PrimitiveType.Utf8)},
         )
         assert result[0].rows[0].value == result_value
+
+
+def test_tz_conversion_fallbacks():
+    # Defensive branches a real-server round-trip never reaches: an unresolvable
+    # zone name is passed through as raw text, and a non-ZoneInfo tzinfo falls
+    # back to its str() name.
+    from ydb.types import _parse_tz, _tz_name
+
+    assert _parse_tz("2019-09-16T18:24:00,Not/AZone") == "2019-09-16T18:24:00,Not/AZone"
+    assert _tz_name(datetime(2019, 9, 17, tzinfo=timezone.utc)) == "UTC"

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -92,8 +92,10 @@ def _parse_tz(value: str) -> typing.Union[datetime, str]:
     wall_clock, _, tz_name = value.partition(",")
     try:
         tz = ZoneInfo(tz_name)
-    except ZoneInfoNotFoundError:
-        # No IANA database available for this zone; return the raw text as-is.
+    except (ZoneInfoNotFoundError, ValueError):
+        # Zone can't be resolved (no tz database, or a malformed/empty name);
+        # return the raw text as-is. ZoneInfo("") raises ValueError, not
+        # ZoneInfoNotFoundError, so both are caught.
         return value
     if "T" in wall_clock:
         naive = datetime.fromisoformat(wall_clock)
@@ -137,7 +139,9 @@ def _from_tz_timestamp(x: str, table_client_settings: table.TableClientSettings)
 
 def _to_tz_timestamp(pb: ydb_value_pb2.Value, value: typing.Union[datetime, str]) -> None:
     if isinstance(value, datetime):
-        pb.text_value = value.strftime("%Y-%m-%dT%H:%M:%S.%f") + "," + _tz_name(value)
+        # isoformat() matches YDB's canonical form: 6-digit microseconds when
+        # non-zero, omitted when zero (YDB strips a trailing ".000000").
+        pb.text_value = value.replace(tzinfo=None).isoformat() + "," + _tz_name(value)
     else:
         pb.text_value = value
 

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -83,9 +83,9 @@ def _to_datetime64(pb: ydb_value_pb2.Value, value: typing.Union[datetime, int]) 
 
 def _tz_name(value: datetime) -> str:
     tz = value.tzinfo
-    if isinstance(tz, ZoneInfo):
-        return tz.key
-    return str(tz)
+    if not isinstance(tz, ZoneInfo):
+        raise ValueError(f"Tz types require a datetime whose tzinfo is a zoneinfo.ZoneInfo, got {tz!r}")
+    return tz.key
 
 
 def _parse_tz(value: str) -> typing.Union[datetime, str]:

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -7,6 +7,7 @@ import enum
 import json
 from . import _utilities, _apis
 from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import typing
 import uuid
 import struct
@@ -78,6 +79,67 @@ def _to_datetime64(pb: ydb_value_pb2.Value, value: typing.Union[datetime, int]) 
         pb.int64_value = (value - epoch) // timedelta(seconds=1)
     else:
         pb.int64_value = value
+
+
+def _tz_name(value: datetime) -> str:
+    tz = value.tzinfo
+    if isinstance(tz, ZoneInfo):
+        return tz.key
+    return str(tz)
+
+
+def _parse_tz(value: str) -> typing.Union[datetime, str]:
+    wall_clock, _, tz_name = value.partition(",")
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        # No IANA database available for this zone; return the raw text as-is.
+        return value
+    if "T" in wall_clock:
+        naive = datetime.fromisoformat(wall_clock)
+    else:
+        parsed_date = date.fromisoformat(wall_clock)
+        naive = datetime(parsed_date.year, parsed_date.month, parsed_date.day)
+    return naive.replace(tzinfo=tz)
+
+
+def _from_tz_date(x: str, table_client_settings: table.TableClientSettings) -> typing.Union[datetime, str]:
+    if table_client_settings is not None and table_client_settings._native_date_in_result_sets:
+        return _parse_tz(x)
+    return x
+
+
+def _to_tz_date(pb: ydb_value_pb2.Value, value: typing.Union[datetime, str]) -> None:
+    if isinstance(value, datetime):
+        pb.text_value = value.strftime("%Y-%m-%d") + "," + _tz_name(value)
+    else:
+        pb.text_value = value
+
+
+def _from_tz_datetime(x: str, table_client_settings: table.TableClientSettings) -> typing.Union[datetime, str]:
+    if table_client_settings is not None and table_client_settings._native_datetime_in_result_sets:
+        return _parse_tz(x)
+    return x
+
+
+def _to_tz_datetime(pb: ydb_value_pb2.Value, value: typing.Union[datetime, str]) -> None:
+    if isinstance(value, datetime):
+        pb.text_value = value.strftime("%Y-%m-%dT%H:%M:%S") + "," + _tz_name(value)
+    else:
+        pb.text_value = value
+
+
+def _from_tz_timestamp(x: str, table_client_settings: table.TableClientSettings) -> typing.Union[datetime, str]:
+    if table_client_settings is not None and table_client_settings._native_timestamp_in_result_sets:
+        return _parse_tz(x)
+    return x
+
+
+def _to_tz_timestamp(pb: ydb_value_pb2.Value, value: typing.Union[datetime, str]) -> None:
+    if isinstance(value, datetime):
+        pb.text_value = value.strftime("%Y-%m-%dT%H:%M:%S.%f") + "," + _tz_name(value)
+    else:
+        pb.text_value = value
 
 
 def _from_json(x: typing.Union[str, bytearray, bytes], table_client_settings: table.TableClientSettings) -> typing.Any:
@@ -213,6 +275,24 @@ class PrimitiveType(enum.Enum):
         None,
         _from_timestamp64,
         _to_timestamp64,
+    )
+    TzDate = (
+        _apis.primitive_types.TZ_DATE,
+        "text_value",
+        _from_tz_date,
+        _to_tz_date,
+    )
+    TzDatetime = (
+        _apis.primitive_types.TZ_DATETIME,
+        "text_value",
+        _from_tz_datetime,
+        _to_tz_datetime,
+    )
+    TzTimestamp = (
+        _apis.primitive_types.TZ_TIMESTAMP,
+        "text_value",
+        _from_tz_timestamp,
+        _to_tz_timestamp,
     )
     Interval = (
         _apis.primitive_types.INTERVAL,

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -7,7 +7,7 @@ import enum
 import json
 from . import _utilities, _apis
 from datetime import date, datetime, timedelta, timezone
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo
 import typing
 import uuid
 import struct
@@ -88,15 +88,12 @@ def _tz_name(value: datetime) -> str:
     return tz.key
 
 
-def _parse_tz(value: str) -> typing.Union[datetime, str]:
+def _parse_tz(value: str) -> datetime:
+    # ZoneInfo raises ZoneInfoNotFoundError (unknown zone / no tz database) or
+    # ValueError (empty/malformed name) — let it propagate so the caller sees an
+    # explicit error instead of a silently wrong type.
     wall_clock, _, tz_name = value.partition(",")
-    try:
-        tz = ZoneInfo(tz_name)
-    except (ZoneInfoNotFoundError, ValueError):
-        # Zone can't be resolved (no tz database, or a malformed/empty name);
-        # return the raw text as-is. ZoneInfo("") raises ValueError, not
-        # ZoneInfoNotFoundError, so both are caught.
-        return value
+    tz = ZoneInfo(tz_name)
     if "T" in wall_clock:
         naive = datetime.fromisoformat(wall_clock)
     else:


### PR DESCRIPTION
Fixes #405.

`TzDate`, `TzDatetime` and `TzTimestamp` were not registered in `PrimitiveType`, so reading them crashed with `AttributeError: 'NoneType' object has no attribute 'get_value'`. This registers all three (stored on the wire as `"<value>,<zone>"` text):

- **Read** (native result sets): a tz-aware `datetime` carrying a `zoneinfo.ZoneInfo` (`TzDate` at midnight); the raw `"<value>,<zone>"` string when the matching `with_native_*_in_result_sets` option is off, mirroring the other date/time types.
- **Write**: a tz-aware `datetime` (its local wall-clock + `ZoneInfo` name is stored) or the raw string.

Based on `drop-python-3.9-and-proto3` for the Python 3.10 baseline (stdlib `zoneinfo`); retarget to `main` once that merges.