### PR TITLE
refactor has_table

### DIFF
--- a/ydb/sqlalchemy/__init__.py
+++ b/ydb/sqlalchemy/__init__.py
@@ -265,13 +265,8 @@ try:
             if schema is not None:
                 raise NotSupportedError
 
-            quote = self.identifier_preparer.quote_identifier
-            qtable = quote(table_name)
-
-            # TODO: use `get_columns` instead.
-            statement = "SELECT * FROM " + qtable
             try:
-                connection.execute(statement)
+                self.get_columns(connection, table_name)
                 return True
             except Exception:
                 return False


### PR DESCRIPTION
Resolves TODO: "use `get_columns` instead."
Use `get_columns` in `has_table` instead of `SELECT *`. Also it improves performance for large tables