### PR TITLE
support datetimes on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-[Unreleased]
 * Fixed `OSError: [Errno 22] Invalid argument` when reading native `Datetime64` value before 1970 (negative Unix timestamps) on Windows: conversion now uses epoch arithmetic instead of `datetime.utcfromtimestamp`
 
 ## 3.31.4 ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[Unreleased]
+* Fixed `OSError: [Errno 22] Invalid argument` when reading native `Datetime64` value before 1970 (negative Unix timestamps) on Windows: conversion now uses epoch arithmetic instead of `datetime.utcfromtimestamp`
+
 ## 3.31.4 ##
 * Fixed async `QuerySessionPool` permanently losing a pool slot when `acquire()` was cancelled while a new session was being created: `asyncio.CancelledError` no longer leaks the pool size counter, so a pool under deadline-driven cancellations can no longer end up exhausted and blocking forever. A cancelled or interrupted session attach now also closes the session instead of orphaning it server-side
 

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -61,7 +61,7 @@ def _from_datetime_number(
 ) -> typing.Union[float, datetime]:
     if table_client_settings is not None and table_client_settings._native_datetime_in_result_sets:
         # x is float when native_datetime_in_result_sets is True
-        return datetime.utcfromtimestamp(typing.cast(float, x))
+        return _EPOCH + timedelta(second=typing.cast(float, x))
     return x
 
 

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -56,9 +56,7 @@ def _to_date32(pb: ydb_value_pb2.Value, value: typing.Union[date, int]) -> None:
         pb.int32_value = value
 
 
-def _from_datetime_number(
-    x: int, table_client_settings: table.TableClientSettings
-) -> typing.Union[int, datetime]:
+def _from_datetime_number(x: int, table_client_settings: table.TableClientSettings) -> typing.Union[int, datetime]:
     if table_client_settings is not None and table_client_settings._native_datetime_in_result_sets:
         # x is the raw Unix timestamp (seconds) from uint32_value/int64_value
         return _EPOCH + timedelta(seconds=x)

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -57,11 +57,11 @@ def _to_date32(pb: ydb_value_pb2.Value, value: typing.Union[date, int]) -> None:
 
 
 def _from_datetime_number(
-    x: typing.Union[float, datetime], table_client_settings: table.TableClientSettings
-) -> typing.Union[float, datetime]:
+    x: int, table_client_settings: table.TableClientSettings
+) -> typing.Union[int, datetime]:
     if table_client_settings is not None and table_client_settings._native_datetime_in_result_sets:
-        # x is float when native_datetime_in_result_sets is True
-        return _EPOCH + timedelta(seconds=typing.cast(float, x))
+        # x is the raw Unix timestamp (seconds) from uint32_value/int64_value
+        return _EPOCH + timedelta(seconds=x)
     return x
 
 

--- a/ydb/types.py
+++ b/ydb/types.py
@@ -61,7 +61,7 @@ def _from_datetime_number(
 ) -> typing.Union[float, datetime]:
     if table_client_settings is not None and table_client_settings._native_datetime_in_result_sets:
         # x is float when native_datetime_in_result_sets is True
-        return _EPOCH + timedelta(second=typing.cast(float, x))
+        return _EPOCH + timedelta(seconds=typing.cast(float, x))
     return x
 
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #890

`datetime.utcfromtimestamp()` raised `OSError` on Windows for negative timestamps. `gmtime` doesn't support negative timestamps. Replaced it with a platform-independent equivalent.

