### PR TITLE
fix docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,13 +83,6 @@ pygments_style = None
 #
 html_theme = 'sphinx_rtd_theme'
 
-html_theme_options = {
-    'fixed_sidebar': True,
-    'page_width': '1140px',
-    'show_related': True,
-    'show_powered_by': False
-}
-
 html_logo = '_static/logo.svg'
 html_favicon = '_static/logo.svg'
 html_baseurl = 'https://ydb-platform.github.io/ydb-python-sdk/'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ html_favicon = '_static/logo.svg'
 html_baseurl = 'https://ydb-platform.github.io/ydb-python-sdk/'
 
 html_show_sourcelink = False
+html_show_sphinx = False
 
 llms_txt_title = 'YDB Python SDK Documentation'
 llms_txt_summary = '''

--- a/docs/driver.rst
+++ b/docs/driver.rst
@@ -166,7 +166,7 @@ AnonymousCredentials
 ^^^^^^^^^^^^^^^^^^^^
 
 No authentication. Use for local or unauthenticated deployments
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/anonymous-credentials>`_):
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/anonymous-credentials>`__):
 
 .. code-block:: python
 
@@ -176,7 +176,7 @@ AccessTokenCredentials
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Pass a static IAM token or API key directly
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/access-token-credentials>`_):
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/access-token-credentials>`__):
 
 .. code-block:: python
 
@@ -185,7 +185,7 @@ Pass a static IAM token or API key directly
 StaticCredentials (username/password)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/static-credentials>`_)
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/static-credentials>`__)
 
 .. code-block:: python
 
@@ -196,7 +196,7 @@ Service Account Credentials
 
 Authenticate as a Yandex Cloud service account using a key file. Requires the ``ydb[yc]``
 extra (``pip install ydb[yc]``)
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/service-account-credentials>`_):
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/service-account-credentials>`__):
 
 .. code-block:: python
 
@@ -212,7 +212,7 @@ Metadata Credentials
 
 Picks up credentials from the instance metadata service when running inside Yandex Cloud
 (Compute VM, Cloud Functions, etc.). Requires ``ydb[yc]``
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/metadata-credentials>`_):
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/metadata-credentials>`__):
 
 .. code-block:: python
 
@@ -225,7 +225,7 @@ OAuth 2.0 Token Exchange
 
 For federated identity scenarios. Exchanges a subject token (e.g. a signed JWT) for a
 YDB access token via an OAuth 2.0 token exchange endpoint
-(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/oauth2-token-exchange-credentials>`_):
+(`full example <https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/oauth2-token-exchange-credentials>`__):
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The documentation build generates the following warnings:
```
(venv) ~/ydb-python-sdk sphinx-build -b html docs docs/_build/html -q
/Users/khabibshahbanov/ydb-python-sdk/docs/driver.rst:2: WARNING: Duplicate explicit target name: "full example".
/Users/khabibshahbanov/ydb-python-sdk/docs/driver.rst:2: WARNING: Duplicate explicit target name: "full example".
/Users/khabibshahbanov/ydb-python-sdk/docs/driver.rst:2: WARNING: Duplicate explicit target name: "full example".
/Users/khabibshahbanov/ydb-python-sdk/docs/driver.rst:2: WARNING: Duplicate explicit target name: "full example".
/Users/khabibshahbanov/ydb-python-sdk/docs/driver.rst:2: WARNING: Duplicate explicit target name: "full example".
WARNING: unsupported theme option 'fixed_sidebar' given
WARNING: unsupported theme option 'page_width' given
WARNING: unsupported theme option 'show_related' given
WARNING: unsupported theme option 'show_powered_by' given
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Fix Sphinx warnings: remove unsupported `html_theme_options` and convert duplicate named links to anonymous ones. Added `html_show_sphinx = False` to hide the "Built with Sphinx" footer line, matching the deployed docs.

